### PR TITLE
Fix some README.md links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ render(<Emoji />, document.querySelector("#app"));
 3. [Virtual-dom](#virtual-dom)
 4. [JSX](#jsx)
    1. [Logical conditions](#logical-conditions)
-   2. [Eventos](eventos)
+   2. [Events](#events)
    3. [children](#children)
       1. [toList](#tolist)
-5. [components as functions](#componentes-como-funciones)
+5. [components as functions](#components-as-functions)
 6. [hooks](#hooks)
-   1. [Why hooks?](#why-hooks?)
+   1. [Why hooks?](#why-hooks)
    2. [useState](#usestate)
    3. [useEffect](#useeffect)
    4. [useReducer](#usereducer)
@@ -35,9 +35,9 @@ render(<Emoji />, document.querySelector("#app"));
    7. [useContext](#usecontext)
 7. [createContext](#createcontext)
 8. [Utilities](#utilities)
-   1. [@atomico/element](#@atomico/element)
-   2. [@atomico/store](#@atomico/store)
-9. [Example](#example)
+   1. [@atomico/element](#atomicoelement)
+   2. [@atomico/store](#atomicostore)
+9. [Examples](#examples)
 
 ## Installation
 
@@ -342,5 +342,7 @@ class MyComponent extends Element {
 ```
 
 > `<host/>` is a special tag within atomic that points to the container given to render, this is ideal to manipulate the WC, on the same diff process.
+
+### @atomico/store
 
 ## Examples


### PR DESCRIPTION
1. Fixes some internals links that were not working.
2. Adds an empty `#atomicostore` section. Like `#examples`, it looks like the section is in development, which is fine!