### PR TITLE
Update for the benefit of animation libraries and web-components in core/src/diff-props.js

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -14,22 +14,21 @@ export const COMPONENT_CLEAR = 0x49;
 export const COMPONENT_REMOVE = 0x43;
 
 export const IGNORE_PROPS = {
-	children: 1
+    children: 1
 };
 
 export const IGNORE_CHILDREN = {
-	innerHTML: 1,
-	textContent: 1,
-	contenteditable: 1
+    innerHTML: 1,
+    textContent: 1,
+    contenteditable: 1
 };
 
 export const HYDRATE_PROPS = {
-	className: 1,
-	id: 1,
-	checked: 1,
-	value: 1,
-	selected: 1
+    className: 1,
+    id: 1,
+    checked: 1,
+    value: 1,
+    selected: 1
 };
 
 export const MEMO_EVENT_NAME = {};
-export const MEMO_CSS_PROPS = {};

--- a/src/core/tests/render/attributes.test.js
+++ b/src/core/tests/render/attributes.test.js
@@ -1,0 +1,29 @@
+import { createContainer } from "../utils";
+import { h, render } from "../../";
+
+describe("core/tests/render: attributes", () => {
+	it("style.setProperty", () => {
+		let scope = createContainer();
+		let ref = {};
+		let prop = "background-color";
+		let value = "teal";
+		let style = {
+			[prop]: value
+		};
+		render(<button ref={ref} style={style} />, scope);
+
+		expect(ref.current.style.getPropertyValue(prop)).toBe(value);
+	});
+	it("json", () => {
+		let scope = createContainer();
+		let ref = {};
+		let value = { index: 10 };
+		let stringValue = JSON.stringify(value);
+
+		render(<button ref={ref} json={value} />, scope);
+
+		expect(ref.current.getAttribute("json")).toBe(stringValue);
+
+		console.log(ref.current);
+	});
+});


### PR DESCRIPTION
## Updates
### style management

**State**, setStyle generated a string style based on an object in order to clean the previous state of style, this is unfriendly to the definition of style in a superior way, for example from the HTML or 
animation libraries.

**PR**, setStyle maintains a local state associated with the one that intervenes, giving as a benefit parallel states associated with style.

### attributes as object

**State**, setProperty defines an object type attribute as `[Object Object]`, this is unfriendly with WCs.

**PR**, setProperty when defining an attribute type object as an attribute use `JSON.stringify`.

