### PR TITLE
fix: quote glob patterns in npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
         }
     },
     "scripts": {
-        "test": "web-test-runner {src,html,tests}/**/*.test.js --node-resolve --coverage --debug",
-        "test:w": "web-test-runner {src,html,tests}/**/*.test.js --node-resolve --watch",
+        "test": "web-test-runner \"{src,html,tests}/**/*.test.js\" --node-resolve --coverage --debug",
+        "test:w": "web-test-runner \"{src,html,tests}/**/*.test.js\" --node-resolve --watch",
         "build:html": "rollup -c",
         "prepare": "npm run build:html && npm run test"
     },


### PR DESCRIPTION
Hi, while running the tests I noticed that on my machine (MacOS 12.3.1, zsh shell) not all tests were executed.

This happens because my shell environment expands the glob pattern before passing it to the command, resulting in a faulty behaviour.
To ensure that the pattern is passed as string to the command, it is therefore a good idea to quote the glob pattern.
More info here: https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784

PS: I used escaped double quotes (`\"`)  instead of single quotes (`'`) because someone [mentioned](https://medium.com/@pkursawe/be-aware-that-on-the-windows-git-bash-you-have-to-use-double-quotes-instead-of-single-ones-in-your-45dbb7fa9145) that only double quotes would be compatible with Windows (not tested). 