### PR TITLE
Add lazy initializer to useReducer hook

### DIFF
--- a/src/hooks/hooks.js
+++ b/src/hooks/hooks.js
@@ -50,12 +50,21 @@ export function useMemo(currentMemo, currentArgs) {
 }
 /**
  * Apply the redux pattern as a hook
- * @param {(state:any,action:any)=>any} reducer
- * @param {any} initialState
+ * @param {(state:any,action:any)=>any} reducer - State reducer function.
+ * @param {any} initialArg - Optional initial state or payload that is passed
+ *      to the lazy state initializer function.
+ * @param {(initialArg)=>any} init - Optional lazy state initializer function.
  */
-export function useReducer(reducer, initialState) {
+export function useReducer(reducer, initialArg, init) {
     let render = useUpdate();
     return useHook((state = []) => {
+        let initialState;
+        if (init !== undefined) {
+            initialState = init(initialArg);
+        } else {
+            initialState = initialArg;
+        }
+
         if (!state[1]) {
             state[0] = initialState;
             state[1] = (action) => {

--- a/src/hooks/hooks.js
+++ b/src/hooks/hooks.js
@@ -58,15 +58,8 @@ export function useMemo(currentMemo, currentArgs) {
 export function useReducer(reducer, initialArg, init) {
     let render = useUpdate();
     return useHook((state = []) => {
-        let initialState;
-        if (init !== undefined) {
-            initialState = init(initialArg);
-        } else {
-            initialState = initialArg;
-        }
-
         if (!state[1]) {
-            state[0] = initialState;
+            state[0] = init != null ? init(initialArg) : initialArg;
             state[1] = (action) => {
                 let nextState = reducer(state[0], action);
                 if (nextState != state[0]) {

--- a/src/hooks/hooks.js
+++ b/src/hooks/hooks.js
@@ -59,7 +59,7 @@ export function useReducer(reducer, initialArg, init) {
     let render = useUpdate();
     return useHook((state = []) => {
         if (!state[1]) {
-            state[0] = init != null ? init(initialArg) : initialArg;
+            state[0] = init !== undefined ? init(initialArg) : initialArg;
             state[1] = (action) => {
                 let nextState = reducer(state[0], action);
                 if (nextState != state[0]) {

--- a/src/hooks/tests/use-reducer.test.js
+++ b/src/hooks/tests/use-reducer.test.js
@@ -13,6 +13,25 @@ describe("src/hooks/use-state", () => {
             expect(state).to.equal(initialState);
         });
     });
+
+    it("Initial state from initializerFunction", () => {
+        let hooks = createHooks();
+        let stateInitializer = (initialArg) => {
+            return initialArg + "Called";
+        };
+        let reducer = (state, action) => {};
+
+        hooks.load(() => {
+            let [state] = useReducer(
+                reducer,
+                "stateInitializer",
+                stateInitializer
+            );
+
+            expect(state).to.equal("stateInitializerCalled");
+        });
+    });
+
     it("Update from reducer", () => {
         let render = () => {};
         let hooks = createHooks(render, null);
@@ -30,6 +49,38 @@ describe("src/hooks/use-state", () => {
 
         hooks.load(() => {
             let [state] = useReducer(reducer, initialState);
+            expect(state).to.equal(refAction.nextState);
+        });
+    });
+
+    it("Call lazy state initializer only one time", () => {
+        let initializerCalls = 0;
+        let render = () => {
+            expect(initializerCalls).to.equal(1);
+        };
+        let hooks = createHooks(render, null);
+        let initialState = {};
+        let stateInitializer = (initArg) => {
+            initializerCalls++;
+            return initArg;
+        };
+        let refAction = { nextState: [] };
+        let reducer = (state, action) => {
+            expect(action).to.equal(refAction);
+            return action.nextState;
+        };
+
+        hooks.load(() => {
+            let [, dispatch] = useReducer(
+                reducer,
+                initialState,
+                stateInitializer
+            );
+            dispatch(refAction);
+        });
+
+        hooks.load(() => {
+            let [state] = useReducer(reducer, initialState, stateInitializer);
             expect(state).to.equal(refAction.nextState);
         });
     });

--- a/src/hooks/tests/use-reducer.test.js
+++ b/src/hooks/tests/use-reducer.test.js
@@ -16,20 +16,30 @@ describe("src/hooks/use-state", () => {
 
     it("Initial state from initializerFunction", () => {
         let hooks = createHooks();
+        let count = 0;
         let stateInitializer = (initialArg) => {
+            count++;
             return initialArg + "Called";
         };
-        let reducer = (state, action) => {};
 
-        hooks.load(() => {
+        let reducer = (state, action) => {};
+        const load = () => {
             let [state] = useReducer(
                 reducer,
                 "stateInitializer",
                 stateInitializer
             );
 
-            expect(state).to.equal("stateInitializerCalled");
-        });
+            return state;
+        };
+
+        let length = 5;
+
+        while (length--) {
+            expect(hooks.load(load)).to.equal("stateInitializerCalled");
+        }
+
+        expect(count).to.equal(1);
     });
 
     it("Update from reducer", () => {

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -317,10 +317,19 @@ export function useLayoutEffect<Args = any[]>(
 /**
  * Lets you use the redux pattern as Hook
  */
-export function useReducer<T = any, A = object>(
-    reducer: Reducer<T, A>,
-    initialState?: T
-): UseReducer<T, A>;
+export function useReducer<S = any, A = object>(
+    reducer: Reducer<S, A>,
+    initialArg?: S
+): UseReducer<S, A>;
+/**
+ * Lets you use the redux pattern as Hook
+ */
+// Overload with state initialization function
+export function useReducer<S = any, A = object, I = unknown>(
+    reducer: Reducer<S, A>,
+    initialArg?: I,
+    init?: (arg: I) => S
+): UseReducer<S, A>;
 /**
  * return to the webcomponent instance for reference
  * ```jsx


### PR DESCRIPTION
To ensure a better compatibility with React based reducers, this adds an optional third argument to the `useReducer` hook to lazy initialize the state in the same way [as React does it](https://reactjs.org/docs/hooks-reference.html#usereducer):
```js
const [state, dispatch] = useReducer(reducer, initialArg, init);
```

Implementation follows the same way as react does it:

https://github.com/facebook/react/blob/ce13860281f833de8a3296b7a3dad9caced102e9/packages/react-reconciler/src/ReactFiberHooks.new.js#L732-L737

## Changes
- Adds third `init` argument to `useReducer`
- Updates types for `useReducer`
- Adds two test cases