### PR TITLE
Add support for function components

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -82,6 +82,11 @@ export let h = (type, p, ...args) => {
               type.prototype instanceof HTMLElement && 2
         : 0;
 
+    //@ts-ignore
+    if (raw === false && type instanceof Function) {
+        return type(props);
+    }
+
     /**
      * @todo look for a more elegant type, since you can't follow the type rules without capturing this
      * @type {any}

--- a/src/tests/render.test.js
+++ b/src/tests/render.test.js
@@ -395,4 +395,13 @@ describe("src/render", () => {
 
         expect(childrenA).to.deep.equal(childrenB);
     });
+
+    it("function instance", () => {
+        let el = document.createElement("div");
+        let Fn = () => html`<img />`;
+
+        render(h("host", null, h(Fn, null)), el);
+
+        expect(el.querySelector(":scope > img")).to.instanceOf(Image);
+    });
 });


### PR DESCRIPTION
I added the check below `let raw` to avoid checking `type.prototype instanceof HTMLElement` twice. So when it is not an instance of HTMLElement `raw` equals `false`.

TypeScript for component props in JSX is already working without any changes 😄 