### PR TITLE
R 1.68.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.67.0",
             "license": "MIT",
             "devDependencies": {
-                "@esm-bundle/chai": "^4.3.4",
+                "@esm-bundle/chai": "^4.3.4-fix.0",
                 "@rollup/plugin-node-resolve": "^13.3.0",
                 "@types/chai": "^4.2.18",
                 "@types/mocha": "^8.0.0",
@@ -55,9 +55,9 @@
             }
         },
         "node_modules/@esm-bundle/chai": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/@esm-bundle/chai/-/chai-4.3.4.tgz",
-            "integrity": "sha512-6Tx35wWiNw7X0nLY9RMx8v3EL8SacCFW+eEZOE9Hc+XxmU5HFE2AFEg+GehUZpiyDGwVvPH75ckGlqC7coIPnA==",
+            "version": "4.3.4-fix.0",
+            "resolved": "https://registry.npmjs.org/@esm-bundle/chai/-/chai-4.3.4-fix.0.tgz",
+            "integrity": "sha512-26SKdM4uvDWlY8/OOOxSB1AqQWeBosCX3wRYUZO7enTAj03CtVxIiCimYVG2WpULcyV51qapK4qTovwkUr5Mlw==",
             "dev": true,
             "dependencies": {
                 "@types/chai": "^4.2.12"
@@ -3481,9 +3481,9 @@
             }
         },
         "@esm-bundle/chai": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/@esm-bundle/chai/-/chai-4.3.4.tgz",
-            "integrity": "sha512-6Tx35wWiNw7X0nLY9RMx8v3EL8SacCFW+eEZOE9Hc+XxmU5HFE2AFEg+GehUZpiyDGwVvPH75ckGlqC7coIPnA==",
+            "version": "4.3.4-fix.0",
+            "resolved": "https://registry.npmjs.org/@esm-bundle/chai/-/chai-4.3.4-fix.0.tgz",
+            "integrity": "sha512-26SKdM4uvDWlY8/OOOxSB1AqQWeBosCX3wRYUZO7enTAj03CtVxIiCimYVG2WpULcyV51qapK4qTovwkUr5Mlw==",
             "dev": true,
             "requires": {
                 "@types/chai": "^4.2.12"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     },
     "homepage": "https://github.com/atomicojs/atomico#readme",
     "devDependencies": {
-        "@esm-bundle/chai": "^4.3.4",
+        "@esm-bundle/chai": "^4.3.4-fix.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@types/chai": "^4.2.18",
         "@types/mocha": "^8.0.0",

--- a/src/core.js
+++ b/src/core.js
@@ -1,9 +1,10 @@
 export * from "./element/custom-element.js";
 export * from "./hooks/hooks.js";
+export * from "./hooks/custom-hooks.js";
 export * from "./element/errors.js";
 export * from "./options.js";
 export { useHook, useHost, useRef, useUpdate } from "./hooks/create-hooks.js";
 export { render, h, Mark, Fragment } from "./render.js";
 export { template } from "./template.js";
 export { css } from "./css.js";
-export * from "./context.js";
+export { useContext, createContext } from "./context.js";

--- a/src/core.js
+++ b/src/core.js
@@ -3,7 +3,13 @@ export * from "./hooks/hooks.js";
 export * from "./hooks/custom-hooks.js";
 export * from "./element/errors.js";
 export * from "./options.js";
-export { useHook, useHost, useRef, useUpdate } from "./hooks/create-hooks.js";
+export {
+    useHook,
+    useHost,
+    useRef,
+    useUpdate,
+    useId,
+} from "./hooks/create-hooks.js";
 export { render, h, Mark, Fragment } from "./render.js";
 export { template } from "./template.js";
 export { css } from "./css.js";

--- a/src/css.js
+++ b/src/css.js
@@ -6,7 +6,7 @@ import { options } from "./options.js";
  * caches the CSSStyleSheet using the css as a reference to the instance
  * @type {{[id:string]:import("core").Sheet}}
  */
-let SHEETS = {};
+const SHEETS = {};
 
 /**
  * Create a Style from a string
@@ -14,7 +14,7 @@ let SHEETS = {};
  * @param  {...any} args
  */
 export function css(template, ...args) {
-    let cssText = (template.raw || template).reduce(
+    const cssText = (template.raw || template).reduce(
         (cssText, part, i) => cssText + part + (args[i] || ""),
         ""
     );
@@ -28,13 +28,13 @@ export function css(template, ...args) {
  */
 export function createSheet(cssText) {
     if (options.sheet) {
-        let sheet = new CSSStyleSheet();
+        const sheet = new CSSStyleSheet();
         // Ts by default does not add .replace yet
         // @ts-ignore
         sheet.replaceSync(cssText);
         return sheet;
     } else {
-        let sheet = $.createElement("style");
+        const sheet = $.createElement("style");
         sheet.textContent = cssText;
         return sheet;
     }

--- a/src/element/custom-element.js
+++ b/src/element/custom-element.js
@@ -22,12 +22,12 @@ export const c = (component, base) => {
      * TS tries to set local class rules, these should be ignored
      * @type {any}
      */
-    let AtomicoElement = class extends (base || HTMLElement) {
+    const AtomicoElement = class extends (base || HTMLElement) {
         constructor() {
             super();
             this._setup();
             this._render = () => component({ ...this._props });
-            for (let prop in values) this[prop] = values[prop];
+            for (const prop in values) this[prop] = values[prop];
         }
         /**
          * @returns {import("core").Sheets}

--- a/src/element/custom-element.js
+++ b/src/element/custom-element.js
@@ -6,17 +6,17 @@ import { flat, isHydrate } from "../utils.js";
 /**
  * @type {import("component").C}
  */
-export let c = (component, base) => {
+export const c = (component, base) => {
     /**
      * @type {import("./set-prototype").Attrs}
      */
-    let attrs = {};
+    const attrs = {};
     /**
      * @type {import("./set-prototype").Values}
      */
-    let values = {};
+    const values = {};
 
-    let { props, styles } = component;
+    const { props, styles } = component;
     /**
      * @todo Discover a more aesthetic solution at the type level
      * TS tries to set local class rules, these should be ignored
@@ -46,6 +46,7 @@ export let c = (component, base) => {
              * @type {Node}
              */
             let lastParentMount;
+
             /**
              * @type {Node}
              */
@@ -86,14 +87,14 @@ export let c = (component, base) => {
 
             this.symbolId = this.symbolId || Symbol();
 
-            let hooks = createHooks(() => this.update(), this);
+            const hooks = createHooks(() => this.update(), this);
 
             let prevent;
 
             let firstRender = true;
 
             // some DOM emulators don't define dataset
-            let hydrate = isHydrate(this);
+            const hydrate = isHydrate(this);
 
             this.update = () => {
                 if (!prevent) {
@@ -106,7 +107,10 @@ export let c = (component, base) => {
                     this.updated = (this.updated || this.mounted)
                         .then(() => {
                             try {
-                                let result = hooks.load(this._render);
+                                const result = hooks.load(this._render);
+
+                                const cleanUseLayoutEffects =
+                                    hooks.cleanEffects();
 
                                 result &&
                                     result.render(this, this.symbolId, hydrate);
@@ -119,16 +123,20 @@ export let c = (component, base) => {
                                     !hydrate && applyStyles(this);
                                 }
 
-                                return hooks.cleanEffects();
+                                return cleanUseLayoutEffects();
                             } finally {
                                 // Remove lock in case of synchronous error
                                 prevent = false;
                             }
                         })
-                        // next tick
-                        .then((cleanEffect) => {
-                            cleanEffect && cleanEffect();
-                        });
+                        .then(
+                            /**
+                             * @param {import("internal/hooks").CleanUseEffects} [cleanUseEffect]
+                             */
+                            (cleanUseEffect) => {
+                                cleanUseEffect && cleanUseEffect();
+                            }
+                        );
                 }
 
                 return this.updated;
@@ -163,7 +171,7 @@ export let c = (component, base) => {
                 // @ts-ignore
                 if (attr === this._ignoreAttr || oldValue === value) return;
                 // Choose the property name to send the update
-                let { prop, type } = attrs[attr];
+                const { prop, type } = attrs[attr];
                 this[prop] = transformValue(type, value);
             } else {
                 // If the attribute does not exist in the scope attrs, the event is sent to super
@@ -180,8 +188,8 @@ export let c = (component, base) => {
         static get observedAttributes() {
             // See if there is an observedAttributes declaration to match with the current one
             // @ts-ignore
-            let superAttrs = super.observedAttributes || [];
-            for (let prop in props) {
+            const superAttrs = super.observedAttributes || [];
+            for (const prop in props) {
                 setPrototype(this.prototype, prop, props[prop], attrs, values);
             }
             return Object.keys(attrs).concat(superAttrs);
@@ -196,13 +204,13 @@ export let c = (component, base) => {
  * @param {import("dom").AtomicoThisInternal} host
  */
 function applyStyles(host) {
-    let { styles } = host.constructor;
-    let { shadowRoot } = host;
+    const { styles } = host.constructor;
+    const { shadowRoot } = host;
     if (shadowRoot && styles.length) {
         /**
          * @type {CSSStyleSheet[]}
          */
-        let sheets = [];
+        const sheets = [];
         flat(styles, (value) => {
             if (value) {
                 if (value instanceof Element) {

--- a/src/element/custom-element.js
+++ b/src/element/custom-element.js
@@ -79,7 +79,7 @@ export const c = (component, base) => {
                             lastParentUnmount != lastParentMount ||
                             !this.isConnected
                         ) {
-                            hooks.cleanEffects(true)();
+                            hooks.cleanEffects(true)()();
                             lastParentUnmount = lastParentMount;
                         }
                     })

--- a/src/element/custom-element.js
+++ b/src/element/custom-element.js
@@ -3,6 +3,21 @@ import { createHooks } from "../hooks/create-hooks.js";
 export { Any } from "./set-prototype.js";
 import { flat, isHydrate } from "../utils.js";
 
+let ID = 0;
+/**
+ *
+ * @param {Element & {dataset?:object}} node
+ * @returns {string|number}
+ */
+const getHydrateId = (node) => {
+    const id = (node?.dataset || {})?.hydrate || "";
+    if (id) {
+        return id;
+    } else {
+        return "c" + ++ID;
+    }
+};
+
 /**
  * @type {import("component").C}
  */
@@ -87,7 +102,11 @@ export const c = (component, base) => {
 
             this.symbolId = this.symbolId || Symbol();
 
-            const hooks = createHooks(() => this.update(), this);
+            const hooks = createHooks(
+                () => this.update(),
+                this,
+                getHydrateId(this)
+            );
 
             let prevent;
 

--- a/src/element/custom-element.js
+++ b/src/element/custom-element.js
@@ -14,7 +14,7 @@ const getHydrateId = (node) => {
     if (id) {
         return id;
     } else {
-        return "c" + ++ID;
+        return "c" + ID++;
     }
 };
 

--- a/src/element/set-prototype.js
+++ b/src/element/set-prototype.js
@@ -4,12 +4,12 @@ import { PropError } from "./errors.js";
  * The Any type avoids the validation of prop types
  * @type {null}
  **/
-export let Any = null;
+export const Any = null;
 
 /**
  * Attributes considered as valid boleanos
  **/
-let TRUE_VALUES = { true: 1, "": 1, 1: 1 };
+const TRUE_VALUES = { true: 1, "": 1, 1: 1 };
 
 /**
  * Constructs the setter and getter of the associated property
@@ -22,7 +22,7 @@ let TRUE_VALUES = { true: 1, "": 1, 1: 1 };
  */
 export function setPrototype(prototype, prop, schema, attrs, values) {
     /**@type {Schema} */
-    let {
+    const {
         type,
         reflect,
         event,
@@ -30,7 +30,7 @@ export function setPrototype(prototype, prop, schema, attrs, values) {
         attr = getAttr(prop),
     } = isObject(schema) && schema != Any ? schema : { type: schema };
 
-    let isCallable = !(type == Function || type == Any);
+    const isCallable = !(type == Function || type == Any);
 
     Object.defineProperty(prototype, prop, {
         configurable: true,
@@ -39,8 +39,8 @@ export function setPrototype(prototype, prop, schema, attrs, values) {
          * @param {any} newValue
          */
         set(newValue) {
-            let oldValue = this[prop];
-            let { error, value } = filterValue(
+            const oldValue = this[prop];
+            const { error, value } = filterValue(
                 type,
                 isCallable && isFunction(newValue)
                     ? newValue(oldValue)
@@ -92,15 +92,17 @@ export function setPrototype(prototype, prop, schema, attrs, values) {
  * @param {Element} node - DOM node to dispatch the event
  * @param {InternalEvent & InternalEventInit} event - Event to dispatch on node
  */
-export let dispatchEvent = (node, { type, base = CustomEvent, ...eventInit }) =>
-    node.dispatchEvent(new base(type, eventInit));
+export const dispatchEvent = (
+    node,
+    { type, base = CustomEvent, ...eventInit }
+) => node.dispatchEvent(new base(type, eventInit));
 
 /**
  * Transform a Camel Case string to a Kebab case
  * @param {string} prop - string to apply the format
  * @returns {string}
  */
-export let getAttr = (prop) => prop.replace(/([A-Z])/g, "-$1").toLowerCase();
+export const getAttr = (prop) => prop.replace(/([A-Z])/g, "-$1").toLowerCase();
 
 /**
  * reflects an attribute value of the given element as context
@@ -109,7 +111,7 @@ export let getAttr = (prop) => prop.replace(/([A-Z])/g, "-$1").toLowerCase();
  * @param {string} attr
  * @param {any} value
  */
-export let reflectValue = (host, type, attr, value) =>
+export const reflectValue = (host, type, attr, value) =>
     value == null || (type == Boolean && !value)
         ? host.removeAttribute(attr)
         : host.setAttribute(
@@ -127,7 +129,7 @@ export let reflectValue = (host, type, attr, value) =>
  * @param {string} value
  * @returns {any}
  */
-export let transformValue = (type, value) =>
+export const transformValue = (type, value) =>
     type == Boolean
         ? !!TRUE_VALUES[value]
         : type == Number
@@ -141,7 +143,7 @@ export let transformValue = (type, value) =>
  * @param {any} value
  * @returns {{error?:boolean,value:any}}
  */
-export let filterValue = (type, value) =>
+export const filterValue = (type, value) =>
     type == null || value == null
         ? { value, error: false }
         : type != String && value === ""

--- a/src/hooks/create-hooks.js
+++ b/src/hooks/create-hooks.js
@@ -27,9 +27,9 @@ export const IdInsertionEffect = Symbol("InsertionEffect");
  * @type {import("core").UseHook}
  */
 export const useHook = (render, effect, tag) => {
-    let { i, hooks } = SCOPE;
+    const { i, hooks } = SCOPE;
 
-    let hook = (hooks[i] = hooks[i] || {});
+    const hook = (hooks[i] = hooks[i] || {});
 
     hook.value = render(hook.value);
     hook.effect = effect;
@@ -73,8 +73,8 @@ export const createHooks = (update, host) => {
      * @param {boolean} [unmounted]
      */
     function cleanEffectsByType(tag, unmounted) {
-        for (let index in hooks) {
-            let hook = hooks[index];
+        for (const index in hooks) {
+            const hook = hooks[index];
             if (hook.effect && hook.tag === tag) {
                 hook.value = hook.effect(hook.value, unmounted);
             }

--- a/src/hooks/create-hooks.js
+++ b/src/hooks/create-hooks.js
@@ -58,9 +58,14 @@ export const useHost = () => useHook((ref = { current: SCOPE.host }) => ref);
 export const useUpdate = () => SCOPE.update;
 
 /**
+ * @type {import("core").UseId}
+ */
+export const useId = () => useHook(() => SCOPE.id + "-" + SCOPE.i);
+
+/**
  * @type {import("internal/hooks").CreateHooks}
  */
-export const createHooks = (update, host) => {
+export const createHooks = (update, host, id = 0) => {
     /**
      * @type {import("internal/hooks").Hooks}
      **/
@@ -84,7 +89,7 @@ export const createHooks = (update, host) => {
      * @type {import("internal/hooks").Load}
      */
     function load(callback) {
-        SCOPE = { host, hooks, update, i: 0 };
+        SCOPE = { host, hooks, update, i: 0, id };
         let value;
         try {
             value = callback();

--- a/src/hooks/custom-hooks.js
+++ b/src/hooks/custom-hooks.js
@@ -1,3 +1,4 @@
 export * from "./custom-hooks/use-prop.js";
 export * from "./custom-hooks/use-event.js";
 export * from "./custom-hooks/use-promise.js";
+export * from "./custom-hooks/use-suspense.js";

--- a/src/hooks/custom-hooks.js
+++ b/src/hooks/custom-hooks.js
@@ -1,0 +1,3 @@
+export * from "./custom-hooks/use-prop.js";
+export * from "./custom-hooks/use-event.js";
+export * from "./custom-hooks/use-promise.js";

--- a/src/hooks/custom-hooks/use-event.js
+++ b/src/hooks/custom-hooks/use-event.js
@@ -4,8 +4,8 @@ import { dispatchEvent } from "../../element/set-prototype.js";
 /**
  * @type {import("core").UseEvent}
  */
-export let useEvent = (type, eventInit = {}) => {
-    let ref = useHost();
+export const useEvent = (type, eventInit = {}) => {
+    const ref = useHost();
     if (!ref[type]) {
         ref[type] = (detail = eventInit.detail) =>
             dispatchEvent(ref.current, {

--- a/src/hooks/custom-hooks/use-promise.js
+++ b/src/hooks/custom-hooks/use-promise.js
@@ -4,13 +4,16 @@ import { useEffect, useState } from "../hooks.js";
  * @type {import("core").UsePromise}
  */
 export const usePromise = (callback, args, autorun = true) => {
-    const [state, setState] = useState({});
+    /**
+     * @type {import("core").ReturnUseState<import("core").ReturnPromise<any>>}
+     */
+    const [state, setState] = useState(autorun ? { pending: autorun } : {});
 
     useEffect(() => {
         if (autorun) {
             let cancel;
 
-            setState({ pending: true });
+            setState(state.pending ? state : { pending: true });
 
             callback(...args).then(
                 (result) => !cancel && setState({ result, fulfilled: true }),
@@ -19,10 +22,9 @@ export const usePromise = (callback, args, autorun = true) => {
 
             return () => (cancel = true);
         } else {
-            setState({});
+            setState((state) => (Object.keys(state).length ? {} : state));
         }
     }, [autorun, ...args]);
 
-    //@ts-ignore
     return state;
 };

--- a/src/hooks/custom-hooks/use-promise.js
+++ b/src/hooks/custom-hooks/use-promise.js
@@ -9,13 +9,18 @@ export const usePromise = (callback, args, autorun = true) => {
      */
     const [state, setState] = useState(autorun ? { pending: autorun } : {});
 
+    /**
+     * @type {any[]}
+     */
+    const currentArgs = args || [];
+
     useEffect(() => {
         if (autorun) {
             let cancel;
 
             setState(state.pending ? state : { pending: true });
 
-            callback(...args).then(
+            callback(...currentArgs).then(
                 (result) => !cancel && setState({ result, fulfilled: true }),
                 (result) => !cancel && setState({ result, rejected: true })
             );
@@ -24,7 +29,7 @@ export const usePromise = (callback, args, autorun = true) => {
         } else {
             setState((state) => (Object.keys(state).length ? {} : state));
         }
-    }, [autorun, ...args]);
+    }, [autorun, ...currentArgs]);
 
     return state;
 };

--- a/src/hooks/custom-hooks/use-promise.js
+++ b/src/hooks/custom-hooks/use-promise.js
@@ -1,12 +1,9 @@
 import { useEffect, useState } from "../hooks.js";
 
 /**
- * @template {(...args:any[])=>Promise<any>} T
- * @param {T} callback
- * @param {any[]} args
- * @param {boolean|undefined} [autorun]
+ * @type {import("core").UsePromise}
  */
-export function usePromise(callback, args = [], autorun = true) {
+export const usePromise = (callback, args, autorun = true) => {
     const [state, setState] = useState({});
 
     useEffect(() => {
@@ -26,5 +23,6 @@ export function usePromise(callback, args = [], autorun = true) {
         }
     }, [autorun, ...args]);
 
+    //@ts-ignore
     return state;
-}
+};

--- a/src/hooks/custom-hooks/use-prop.js
+++ b/src/hooks/custom-hooks/use-prop.js
@@ -8,6 +8,9 @@ export let useProp = (name) => {
     let ref = useHost();
     if (name in ref.current) {
         if (!ref[name]) {
+            /**
+             * @type {import("core").ReturnUseProp<any>}
+             */
             let updater = [
                 null,
                 (nextValue) => (ref.current[name] = nextValue),
@@ -15,6 +18,7 @@ export let useProp = (name) => {
             ref[name] = updater;
         }
         ref[name][0] = ref.current[name];
+
         return ref[name];
     }
 };

--- a/src/hooks/custom-hooks/use-prop.js
+++ b/src/hooks/custom-hooks/use-prop.js
@@ -4,14 +4,14 @@ import { useHost } from "../create-hooks.js";
  *
  * @type {import("core").UseProp}
  */
-export let useProp = (name) => {
-    let ref = useHost();
+export const useProp = (name) => {
+    const ref = useHost();
     if (name in ref.current) {
         if (!ref[name]) {
             /**
              * @type {import("core").ReturnUseProp<any>}
              */
-            let updater = [
+            const updater = [
                 null,
                 (nextValue) => (ref.current[name] = nextValue),
             ];

--- a/src/hooks/custom-hooks/use-suspense.js
+++ b/src/hooks/custom-hooks/use-suspense.js
@@ -1,0 +1,90 @@
+import { useHost, IdSuspense } from "../create-hooks.js";
+import { useEvent } from "../custom-hooks/use-event.js";
+import { usePromise } from "../custom-hooks/use-promise.js";
+import { useLayoutEffect, useState } from "../hooks.js";
+import { addListener } from "../../utils.js";
+
+/**
+ * @type {EventInit}
+ */
+const Config = { bubbles: true, composed: true };
+
+const Type = {
+    pending: "PendingSuspense",
+    fulfilled: "FulfilledSuspense",
+    rejected: "RejectedSuspense",
+};
+
+export function useAsync(callback, args) {
+    const host = useHost();
+    const dispatchPending = useEvent(Type.pending, Config);
+    const dispatchFulfilled = useEvent(Type.fulfilled, Config);
+    const dispatchRejected = useEvent(Type.rejected, Config);
+
+    const status = usePromise(callback, args);
+
+    useLayoutEffect(() => {
+        const { current } = host;
+
+        console.log(status);
+
+        if (status.pending) {
+            dispatchPending(current);
+        } else if (status.fulfilled) {
+            dispatchFulfilled(current);
+        } else {
+            dispatchRejected(current);
+        }
+    }, [status]);
+
+    if (status.pending) {
+        throw IdSuspense;
+    }
+
+    return status.result;
+}
+
+export function useSuspense() {
+    const host = useHost();
+    const [status, setStatus] = useState({ pending: true });
+
+    useLayoutEffect(() => {
+        const { current } = host;
+        const task = new Set();
+        /**
+         * @param {CustomEvent<HTMLElement>} event
+         */
+        const handler = (event) => {
+            event.stopImmediatePropagation();
+            const { detail, type } = event;
+            if (type === Type.pending) {
+                task.add(detail);
+                setStatus((status) =>
+                    status.pending ? status : { pending: true }
+                );
+            } else if (type === Type.fulfilled) {
+                task.delete(detail);
+                setStatus((status) =>
+                    task.size
+                        ? status
+                        : status.pending
+                        ? { fulfilled: true }
+                        : status
+                );
+            } else if (type === Type.rejected) {
+                task.delete(detail);
+                setStatus({ rejected: true });
+            }
+        };
+
+        const unlisteners = [
+            addListener(current, Type.pending, handler),
+            addListener(current, Type.fulfilled, handler),
+            addListener(current, Type.rejected, handler),
+        ];
+
+        return () => unlisteners.forEach((unlistener) => unlistener());
+    }, []);
+
+    return status;
+}

--- a/src/hooks/custom-hooks/use-suspense.js
+++ b/src/hooks/custom-hooks/use-suspense.js
@@ -38,7 +38,7 @@ export const useAsync = (callback, args) => {
     if (status.pending) {
         throw IdSuspense;
     }
-
+    //@ts-ignore
     return status.result;
 };
 

--- a/src/hooks/custom-hooks/use-suspense.js
+++ b/src/hooks/custom-hooks/use-suspense.js
@@ -1,7 +1,7 @@
 import { useHost, IdSuspense } from "../create-hooks.js";
 import { useEvent } from "../custom-hooks/use-event.js";
 import { usePromise } from "../custom-hooks/use-promise.js";
-import { useLayoutEffect, useState } from "../hooks.js";
+import { useInsertionEffect, useLayoutEffect, useState } from "../hooks.js";
 import { addListener } from "../../utils.js";
 
 /**
@@ -15,7 +15,10 @@ const Type = {
     rejected: "RejectedSuspense",
 };
 
-export function useAsync(callback, args) {
+/**
+ * @type {import("core").UseAsync}
+ */
+export const useAsync = (callback, args) => {
     const host = useHost();
     const dispatchPending = useEvent(Type.pending, Config);
     const dispatchFulfilled = useEvent(Type.fulfilled, Config);
@@ -25,9 +28,6 @@ export function useAsync(callback, args) {
 
     useLayoutEffect(() => {
         const { current } = host;
-
-        console.log(status);
-
         if (status.pending) {
             dispatchPending(current);
         } else if (status.fulfilled) {
@@ -42,13 +42,21 @@ export function useAsync(callback, args) {
     }
 
     return status.result;
-}
+};
 
-export function useSuspense() {
+/**
+ *
+ * @type {import("core").UseSuspense}
+ */
+
+export const useSuspense = () => {
     const host = useHost();
+    /**
+     * @type {import("internal/hooks").ReturnSetStateUseSuspense}
+     */
     const [status, setStatus] = useState({ pending: true });
 
-    useLayoutEffect(() => {
+    useInsertionEffect(() => {
         const { current } = host;
         const task = new Set();
         /**
@@ -73,7 +81,9 @@ export function useSuspense() {
                 );
             } else if (type === Type.rejected) {
                 task.delete(detail);
-                setStatus({ rejected: true });
+                setStatus((status) =>
+                    status.rejected ? status : { rejected: true }
+                );
             }
         };
 
@@ -87,4 +97,4 @@ export function useSuspense() {
     }, []);
 
     return status;
-}
+};

--- a/src/hooks/hooks.js
+++ b/src/hooks/hooks.js
@@ -56,7 +56,7 @@ export const useReducer = (reducer, initialArg, init) => {
         if (!state[1]) {
             state[0] = init !== undefined ? init(initialArg) : initialArg;
             state[1] = (action) => {
-                let nextState = reducer(state[0], action);
+                const nextState = reducer(state[0], action);
                 if (nextState != state[0]) {
                     state[0] = nextState;
                     update();

--- a/src/hooks/hooks.js
+++ b/src/hooks/hooks.js
@@ -3,9 +3,6 @@ import { useHook, useUpdate } from "./create-hooks.js";
 import { isEqualArray, isFunction } from "../utils.js";
 
 export * from "./use-effect.js";
-export * from "./custom-hooks/use-prop.js";
-export * from "./custom-hooks/use-event.js";
-export * from "./custom-hooks/use-promise.js";
 
 /**
  * Create a persistent local state

--- a/src/hooks/hooks.js
+++ b/src/hooks/hooks.js
@@ -8,13 +8,14 @@ export * from "./use-effect.js";
  * Create a persistent local state
  * @type {import("core").UseState}
  */
-export let useState = (initialState) => {
+export const useState = (initialState) => {
     // retrieve the render to request an update
-    let update = useUpdate();
+    const update = useUpdate();
 
     return useHook((state = []) => {
         if (!state[1]) {
-            let load = (value) => (isFunction(value) ? value(state[0]) : value);
+            const load = (value) =>
+                isFunction(value) ? value(state[0]) : value;
             // Initialize the initial state
             state[0] = load(initialState);
             // Associate an immutable setState to the state instance
@@ -35,8 +36,8 @@ export let useState = (initialState) => {
  * Memorize the return of a callback
  * @type {import("core").UseMemo}
  */
-export let useMemo = (currentMemo, currentArgs) => {
-    let [state] = useHook(([state, args, cycle = 0] = []) => {
+export const useMemo = (currentMemo, currentArgs) => {
+    const [state] = useHook(([state, args, cycle = 0] = []) => {
         if (!args || (args && !isEqualArray(args, currentArgs))) {
             state = currentMemo();
         }
@@ -49,8 +50,8 @@ export let useMemo = (currentMemo, currentArgs) => {
  * Apply the redux pattern as a hook
  * @type {import("core").UseReducer}
  */
-export let useReducer = (reducer, initialArg, init) => {
-    let render = useUpdate();
+export const useReducer = (reducer, initialArg, init) => {
+    const update = useUpdate();
     return useHook((state = []) => {
         if (!state[1]) {
             state[0] = init !== undefined ? init(initialArg) : initialArg;
@@ -58,7 +59,7 @@ export let useReducer = (reducer, initialArg, init) => {
                 let nextState = reducer(state[0], action);
                 if (nextState != state[0]) {
                     state[0] = nextState;
-                    render();
+                    update();
                 }
             };
         }
@@ -71,4 +72,4 @@ export let useReducer = (reducer, initialArg, init) => {
  * variables regardless of the render
  * @type {import("core").UseCallback}
  */
-export let useCallback = (callback, args) => useMemo(() => callback, args);
+export const useCallback = (callback, args) => useMemo(() => callback, args);

--- a/src/hooks/tests/create-hooks.test.js
+++ b/src/hooks/tests/create-hooks.test.js
@@ -100,7 +100,7 @@ describe("src/hooks/create-hooks", () => {
             ++cycleRoot;
             hooks.load(hooksScope);
             // clean useLayoutEffect and then useEffect
-            hooks.cleanEffects()();
+            hooks.cleanEffects()()();
         };
 
         let size = 100;

--- a/src/hooks/tests/create-hooks.test.js
+++ b/src/hooks/tests/create-hooks.test.js
@@ -1,5 +1,13 @@
 import { expect } from "@esm-bundle/chai";
-import { useHook, createHooks, useUpdate, useHost } from "../create-hooks.js";
+import {
+    useHook,
+    createHooks,
+    useUpdate,
+    useHost,
+    IdEffect,
+    IdInsertionEffect,
+    IdLayoutEffect,
+} from "../create-hooks.js";
 
 describe("src/hooks/create-hooks", () => {
     /**
@@ -104,6 +112,7 @@ describe("src/hooks/create-hooks", () => {
         expect(cycleRoot).to.equal(cycleScope);
     });
     /**
+     * @todo !
      * The hook life cycle is transmitted internally by the useHook hook,
      * this resive 3 callback:
      *
@@ -119,27 +128,44 @@ describe("src/hooks/create-hooks", () => {
         hooks.load(() => {
             useHook(
                 () => {
-                    steps.push("render");
+                    steps.push("render 1");
                 },
                 () => {
-                    steps.push("layoutEffect");
+                    steps.push("InsertionEffect");
+                },
+                IdInsertionEffect
+            );
+            useHook(
+                () => {
+                    steps.push("render 2");
                 },
                 () => {
-                    steps.push("effect");
-                }
+                    steps.push("LayoutEffect");
+                },
+                IdLayoutEffect
+            );
+            useHook(
+                () => {
+                    steps.push("render 3");
+                },
+                () => {
+                    steps.push("Effect");
+                },
+                IdEffect
             );
         });
 
-        expect(steps).to.deep.equal(["render"]);
+        hooks.cleanEffects()()();
 
-        let clearLastEffects = hooks.cleanEffects();
-
-        expect(steps).to.deep.equal(["render", "layoutEffect"]);
-
-        clearLastEffects();
-
-        expect(steps).to.deep.equal(["render", "layoutEffect", "effect"]);
+        expect(steps).to.deep.equal([
+            "render 1",
+            "render 2",
+            "render 3",
+            "InsertionEffect",
+            "LayoutEffect",
+            "Effect",
+        ]);
     });
 
-    //it("hooks.load: unmounted layoutEffect and useEffect", () => {});
+    it("hooks.load: unmounted layoutEffect and useEffect", () => {});
 });

--- a/src/hooks/tests/use-effect.test.js
+++ b/src/hooks/tests/use-effect.test.js
@@ -20,7 +20,7 @@ describe("src/hooks/use-effect", () => {
 
         let update = () => {
             hooks.load(load);
-            hooks.cleanEffects()();
+            hooks.cleanEffects()()();
         };
 
         update();
@@ -52,7 +52,7 @@ describe("src/hooks/use-effect", () => {
 
         let update = (param) => {
             hooks.load(() => load(param));
-            hooks.cleanEffects()();
+            hooks.cleanEffects()()();
         };
 
         update(1);

--- a/src/hooks/tests/use-effect.test.js
+++ b/src/hooks/tests/use-effect.test.js
@@ -75,8 +75,8 @@ describe("src/hooks/use-effect", () => {
 
         hooks.load(load);
         // Initialize the effect
-        hooks.cleanEffects()();
+        hooks.cleanEffects()()();
         // Unmount effect
-        hooks.cleanEffects(true)();
+        hooks.cleanEffects(true)()();
     });
 });

--- a/src/hooks/tests/use-id.test.js
+++ b/src/hooks/tests/use-id.test.js
@@ -1,0 +1,19 @@
+import { expect } from "@esm-bundle/chai";
+import { createHooks, useId } from "../create-hooks.js";
+
+describe("useId", () => {
+    it("default", () => {
+        const hooks = createHooks();
+
+        const result = hooks.load(() => [useId(), useId(), useId()]);
+
+        expect(result).to.deep.equal(["0-0", "0-1", "0-2"]);
+    });
+    it("custom", () => {
+        const hooks = createHooks(undefined, undefined, "s0");
+
+        const result = hooks.load(() => [useId(), useId(), useId()]);
+
+        expect(result).to.deep.equal(["s0-0", "s0-1", "s0-2"]);
+    });
+});

--- a/src/hooks/tests/use-layout-effect.test.js
+++ b/src/hooks/tests/use-layout-effect.test.js
@@ -20,7 +20,7 @@ describe("src/hooks/use-effect", () => {
 
         let update = () => {
             hooks.load(load);
-            hooks.cleanEffects()();
+            hooks.cleanEffects()()();
         };
 
         update();
@@ -52,7 +52,7 @@ describe("src/hooks/use-effect", () => {
 
         let update = (param) => {
             hooks.load(() => load(param));
-            hooks.cleanEffects()();
+            hooks.cleanEffects()()();
         };
 
         update(1);
@@ -74,8 +74,8 @@ describe("src/hooks/use-effect", () => {
             useLayoutEffect(() => done, []);
         });
         // Initialize the effect
-        hooks.cleanEffects()();
+        hooks.cleanEffects()()();
         // Unmount effect
-        hooks.cleanEffects(true)();
+        hooks.cleanEffects(true)()();
     });
 });

--- a/src/hooks/tests/use-memo.test.js
+++ b/src/hooks/tests/use-memo.test.js
@@ -34,7 +34,7 @@ describe("src/hooks/use-memo", () => {
 
         let update = () => {
             hooks.load(load);
-            hooks.cleanEffects()();
+            hooks.cleanEffects()()();
         };
 
         update();
@@ -54,7 +54,7 @@ describe("src/hooks/use-memo", () => {
 
         let update = (value) => {
             hooks.load(() => load(value));
-            hooks.cleanEffects()();
+            hooks.cleanEffects()()();
         };
 
         update(0); // values[0] = 0

--- a/src/hooks/tests/use-promise.test.js
+++ b/src/hooks/tests/use-promise.test.js
@@ -7,15 +7,13 @@ describe("usePromise", () => {
         let cycle = 0;
 
         const load = () => {
-            const promise = usePromise(async () => 10);
+            const promise = usePromise(async () => 10, []);
+
             switch (cycle++) {
                 case 0:
-                    expect(promise).to.deep.equal({});
-                    break;
-                case 1:
                     expect(promise).to.deep.equal({ pending: true });
                     break;
-                case 2:
+                case 1:
                     expect(promise).to.deep.equal({
                         result: 10,
                         fulfilled: true,
@@ -37,15 +35,13 @@ describe("usePromise", () => {
         let cycle = 0;
 
         const load = () => {
-            const promise = usePromise(() => Promise.reject(10));
+            const promise = usePromise(() => Promise.reject(10), []);
             switch (cycle++) {
                 case 0:
-                    expect(promise).to.deep.equal({});
-                    break;
-                case 1:
                     expect(promise).to.deep.equal({ pending: true });
                     break;
-                case 2:
+
+                case 1:
                     expect(promise).to.deep.equal({
                         result: 10,
                         rejected: true,

--- a/src/hooks/tests/use-promise.test.js
+++ b/src/hooks/tests/use-promise.test.js
@@ -29,7 +29,7 @@ describe("usePromise", () => {
 
         render();
 
-        hooks.cleanEffects()();
+        hooks.cleanEffects()()();
     });
     it("rejected", (done) => {
         let cycle = 0;
@@ -57,6 +57,6 @@ describe("usePromise", () => {
 
         render();
 
-        hooks.cleanEffects()();
+        hooks.cleanEffects()()();
     });
 });

--- a/src/hooks/tests/use-suspense.test.js
+++ b/src/hooks/tests/use-suspense.test.js
@@ -26,13 +26,10 @@ describe("useSuspense", () => {
         };
 
         const childLoad = () => {
-            const result = useAsync(
-                () =>
-                    new Promise((resolve) =>
-                        setTimeout(resolve, 200, { ok: "success!" })
-                    ),
-                []
-            );
+            const result = useAsync(async () => {
+                await new Promise((resolve) => setTimeout(resolve, 200));
+                return { ok: "success!" };
+            }, []);
 
             switch (cycleChild++) {
                 case 0:

--- a/src/hooks/tests/use-suspense.test.js
+++ b/src/hooks/tests/use-suspense.test.js
@@ -1,0 +1,120 @@
+import { expect } from "@esm-bundle/chai";
+import { createHooks } from "../create-hooks.js";
+import { useSuspense, useAsync } from "../custom-hooks/use-suspense.js";
+
+describe("useSuspense", () => {
+    it("fulfilled", (done) => {
+        let cycleParent = 0;
+        let cycleChild = 0;
+
+        const parent = document.createElement("div");
+        const child = document.createElement("div");
+
+        parent.append(child);
+
+        const parentLoad = () => {
+            const status = useSuspense();
+
+            switch (cycleParent++) {
+                case 0:
+                    expect(status).to.deep.equal({ pending: true });
+                    break;
+                case 1:
+                    expect(status).to.deep.equal({ fulfilled: true });
+                    break;
+            }
+        };
+
+        const childLoad = () => {
+            const result = useAsync(
+                () =>
+                    new Promise((resolve) =>
+                        setTimeout(resolve, 200, { ok: "success!" })
+                    ),
+                []
+            );
+
+            switch (cycleChild++) {
+                case 0:
+                    expect(result).to.deep.equal({ ok: "success!" });
+                    done();
+                    break;
+            }
+        };
+
+        const parentRender = () => {
+            parentHooks.load(parentLoad);
+            parentHooks.cleanEffects()()();
+        };
+
+        const parentHooks = createHooks(parentRender, parent);
+
+        parentRender();
+
+        const childRender = () => {
+            childHooks.load(childLoad);
+            childHooks.cleanEffects()()();
+        };
+
+        const childHooks = createHooks(childRender, child);
+
+        childRender();
+    });
+    it("rejected", (done) => {
+        let cycleParent = 0;
+        let cycleChild = 0;
+
+        const parent = document.createElement("div");
+        const child = document.createElement("div");
+
+        parent.append(child);
+
+        const parentLoad = () => {
+            const status = useSuspense();
+
+            switch (cycleParent++) {
+                case 0:
+                    expect(status).to.deep.equal({ pending: true });
+                    break;
+                case 1:
+                    expect(status).to.deep.equal({ fulfilled: true });
+                    break;
+            }
+        };
+
+        const childLoad = () => {
+            const result = useAsync(
+                () =>
+                    new Promise((resolve, reject) =>
+                        setTimeout(reject, 200, { ok: "rejected!" })
+                    ),
+                []
+            );
+
+            switch (cycleChild++) {
+                case 0:
+                    expect(result).to.deep.equal({ ok: "rejected!" });
+                    done();
+                    break;
+            }
+        };
+
+        const parentRender = () => {
+            parentHooks.load(parentLoad);
+            parentHooks.cleanEffects()()();
+        };
+
+        const parentHooks = createHooks(parentRender, parent);
+
+        parentRender();
+
+        const childRender = () => {
+            childHooks.load(childLoad);
+            childHooks.cleanEffects()()();
+        };
+
+        const childHooks = createHooks(childRender, child);
+
+        childRender();
+    });
+});

--- a/src/hooks/use-effect.js
+++ b/src/hooks/use-effect.js
@@ -1,34 +1,24 @@
-import { useHook } from "./create-hooks.js";
+import {
+    useHook,
+    IdLayoutEffect,
+    IdEffect,
+    IdInsertionEffect,
+} from "./create-hooks.js";
 import { isEqualArray, isFunction } from "../utils.js";
 
 /**
  * useLayoutEffect and useEffect have a similar algorithm
  * in that the position of the callback varies.
- * @param {1|2} type - 1 = useLayouteffect, 2 = useEffect
+ * @param {IdLayoutEffect|IdEffect|IdInsertionEffect} type
+ * @return {import("internal/hooks").UseAnyEffect}
  */
 let createEffect = (type) => (currentEffect, currentArgs) => {
-    /**
-     * clear or initialize the effect hook
-     * @param {[Collector|boolean,any]} state
-     * @param {*} unmounted
-     */
-    let effect = ([collector, args], unmounted) => {
-        if (unmounted) {
-            // ts does not infer the following conditional
-            //@ts-ignore
-            isFunction(collector) && collector();
-        } else {
-            return [collector ? collector : currentEffect(), args];
-        }
-    };
-
     useHook(
         /**
          * Clean the effect hook
-         * @param {[Collector|boolean,any[]]} state
+         * @type {import("internal/hooks").CollectorEffect}
          */
-        // TS does not infer the optional parameter
-        // @ts-ignore
+
         ([collector, args] = []) => {
             if (args || !args) {
                 if (args && isEqualArray(args, currentArgs)) {
@@ -43,18 +33,23 @@ let createEffect = (type) => (currentEffect, currentArgs) => {
             return [collector, currentArgs];
         },
         /**
-         * The following block is internal to compress code by reusing
-         * the same logic for useLayoutEffect and useEffect
+         * @returns {any}
          */
-        type == 1 && effect,
-        type == 2 && effect
+        ([collector, args], unmounted) => {
+            if (unmounted) {
+                // ts does not infer the following conditional
+                isFunction(collector) && collector();
+                return [];
+            } else {
+                return [collector ? collector : currentEffect(), args];
+            }
+        },
+        type
     );
 };
 
-export let useLayoutEffect = createEffect(1);
+export let useLayoutEffect = createEffect(IdLayoutEffect);
 
-export let useEffect = createEffect(2);
+export let useEffect = createEffect(IdEffect);
 
-/**
- * @callback Collector
- */
+export let useInsertionEffect = createEffect(IdInsertionEffect);

--- a/src/hooks/use-effect.js
+++ b/src/hooks/use-effect.js
@@ -12,7 +12,7 @@ import { isEqualArray, isFunction } from "../utils.js";
  * @param {IdLayoutEffect|IdEffect|IdInsertionEffect} type
  * @return {import("internal/hooks").UseAnyEffect}
  */
-let createEffect = (type) => (currentEffect, currentArgs) => {
+const createEffect = (type) => (currentEffect, currentArgs) => {
     useHook(
         /**
          * Clean the effect hook
@@ -48,8 +48,8 @@ let createEffect = (type) => (currentEffect, currentArgs) => {
     );
 };
 
-export let useLayoutEffect = createEffect(IdLayoutEffect);
+export const useLayoutEffect = createEffect(IdLayoutEffect);
 
-export let useEffect = createEffect(IdEffect);
+export const useEffect = createEffect(IdEffect);
 
-export let useInsertionEffect = createEffect(IdInsertionEffect);
+export const useInsertionEffect = createEffect(IdInsertionEffect);

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,7 @@
 /**
  * @type {import("core").Options}
  */
-export let options = {
+export const options = {
     //@ts-ignore
     sheet: !!document.adoptedStyleSheets,
 };

--- a/src/render.js
+++ b/src/render.js
@@ -2,13 +2,13 @@ import { isFunction, isObject, isArray, flat, isHydrate } from "./utils.js";
 import { options } from "./options.js";
 // Object used to know which properties are extracted directly
 // from the node to verify 2 if they have changed
-let VAL_FROM_PROPS = {
+const VAL_FROM_PROPS = {
     checked: 1,
     value: 1,
     selected: 1,
 };
 // Map of attributes that escape the property analysis
-let PROPS_AS_ATTRS = {
+const PROPS_AS_ATTRS = {
     list: 1,
     type: 1,
     size: 1,
@@ -20,7 +20,7 @@ let PROPS_AS_ATTRS = {
     slot: 1,
 };
 // escapes from diffProps compare process
-let INTERNAL_PROPS = {
+const INTERNAL_PROPS = {
     shadowDom: 1,
     staticNode: 1,
     cloneNode: 1,
@@ -28,21 +28,21 @@ let INTERNAL_PROPS = {
     key: 1,
 };
 // Immutable for comparison of empty properties
-let EMPTY_PROPS = {};
+const EMPTY_PROPS = {};
 // Immutable for empty children comparison
-let EMPTY_CHILDREN = [];
+const EMPTY_CHILDREN = [];
 // Alias for document
-export let $ = document;
+export const $ = document;
 // Fragment marker
 export class Mark extends Text {}
 
-let SymbolFor = Symbol.for;
+const SymbolFor = Symbol.for;
 // Default ID used to store the Vnode state
-export let ID = SymbolFor("Atomico.ID");
+export const ID = SymbolFor("Atomico.ID");
 // Internal marker to know if the Vnode comes from Atomico
-export let $$ = SymbolFor("Atomico.$$");
+export const $$ = SymbolFor("Atomico.$$");
 
-export let REF = SymbolFor("Atomico.REF");
+export const REF = SymbolFor("Atomico.REF");
 
 export const Fragment = () => {};
 
@@ -59,11 +59,11 @@ export function RENDER(node, id, hydrate) {
 /**
  * @type {import("vnode").H}
  */
-export let h = (type, p, ...args) => {
+export const h = (type, p, ...args) => {
     /**
      * @type {any}
      */
-    let props = p || EMPTY_PROPS;
+    const props = p || EMPTY_PROPS;
 
     let { children } = props;
 
@@ -75,7 +75,7 @@ export let h = (type, p, ...args) => {
         return children;
     }
 
-    let raw = type
+    const raw = type
         ? type instanceof Node
             ? 1
             : //@ts-ignore
@@ -93,12 +93,12 @@ export let h = (type, p, ...args) => {
      * @todo look for a more elegant type, since you can't follow the type rules without capturing this
      * @type {any}
      */
-    let render = options.render || RENDER;
+    const render = options.render || RENDER;
 
     /**
      * @type {import("vnode").VNodeAny}
      */
-    let vnode = {
+    const vnode = {
         $$,
         type,
         props,
@@ -176,20 +176,19 @@ function diff(newVnode, node, id = ID, hydrate, isSvg) {
         }
     }
 
+    const oldVNodeStore = node[id] ? node[id] : EMPTY_PROPS;
+
     /**
      * @type {import("vnode").VNodeStore}
      */
-    let {
-        vnode = EMPTY_PROPS,
-        cycle = 0,
-        fragment,
-        handlers,
-    } = node[id] ? node[id] : EMPTY_PROPS;
+    const { vnode = EMPTY_PROPS, cycle = 0 } = oldVNodeStore;
+
+    let { fragment, handlers } = oldVNodeStore;
 
     /**
      * @type {import("vnode").VNodeGeneric}
      */
-    let { children = EMPTY_CHILDREN, props = EMPTY_PROPS } = vnode;
+    const { children = EMPTY_CHILDREN, props = EMPTY_PROPS } = vnode;
 
     /**
      * @type {import("vnode").Handlers}
@@ -206,7 +205,8 @@ function diff(newVnode, node, id = ID, hydrate, isSvg) {
         diffProps(node, props, newVnode.props, handlers, isSvg);
 
     if (newVnode.children !== children) {
-        let nextParent = newVnode.shadow ? node.shadowRoot : node;
+        const nextParent = newVnode.shadow ? node.shadowRoot : node;
+
         fragment = renderChildren(
             newVnode.children,
             /**
@@ -221,9 +221,7 @@ function diff(newVnode, node, id = ID, hydrate, isSvg) {
         );
     }
 
-    cycle++;
-
-    node[id] = { vnode: newVnode, handlers, fragment, cycle };
+    node[id] = { vnode: newVnode, handlers, fragment, cycle: cycle + 1 };
 
     return node;
 }
@@ -234,8 +232,12 @@ function diff(newVnode, node, id = ID, hydrate, isSvg) {
  * @return {import("vnode").Fragment}
  */
 function createFragment(parent, hydrate) {
-    let markStart = new Mark("");
-    let markEnd = new Mark("");
+    const markStart = new Mark("");
+    const markEnd = new Mark("");
+
+    /**
+     * @type {Element}
+     */
     let node;
 
     parent[hydrate ? "prepend" : "append"](markStart);
@@ -277,9 +279,9 @@ export function renderChildren(children, fragment, parent, id, hydrate, isSvg) {
     children =
         children == null ? null : isArray(children) ? children : [children];
 
-    let nextFragment = fragment || createFragment(parent, hydrate);
+    const nextFragment = fragment || createFragment(parent, hydrate);
 
-    let { markStart, markEnd, keyes } = nextFragment;
+    const { markStart, markEnd, keyes } = nextFragment;
     /**
      * @type {import("vnode").Keyes}
      */
@@ -288,7 +290,8 @@ export function renderChildren(children, fragment, parent, id, hydrate, isSvg) {
      * Eliminate intermediate nodes that are not used in the process in keyed
      * @type {Set<ChildNode>}
      */
-    let removeNodes = keyes && new Set();
+    const removeNodes = keyes && new Set();
+
     /**
      * RULES: that you should never exceed "c"
      * @type {ChildNode}
@@ -297,14 +300,12 @@ export function renderChildren(children, fragment, parent, id, hydrate, isSvg) {
 
     children &&
         flat(children, (child) => {
-            let type = typeof child;
-
-            if (type == "object" && child.$$ != $$) {
+            if (typeof child == "object" && child.$$ != $$) {
                 return;
             }
 
-            let key = child.$$ && child.key;
-            let childKey = keyes && key != null && keyes.get(key);
+            const key = child.$$ && child.key;
+            const childKey = keyes && key != null && keyes.get(key);
             // check if the displacement affected the index of the child with
             // assignment of key, if so the use of nextSibling is prevented
             if (currentNode != markEnd && currentNode === childKey) {
@@ -314,12 +315,12 @@ export function renderChildren(children, fragment, parent, id, hydrate, isSvg) {
                     currentNode == markEnd ? markEnd : currentNode.nextSibling;
             }
 
-            let childNode = keyes ? childKey : currentNode;
+            const childNode = keyes ? childKey : currentNode;
 
             let nextChildNode = childNode;
             // text node diff
             if (!child.$$) {
-                let text = child + "";
+                const text = child + "";
                 if (
                     !(nextChildNode instanceof Text) ||
                     nextChildNode instanceof Mark
@@ -364,9 +365,9 @@ export function renderChildren(children, fragment, parent, id, hydrate, isSvg) {
     if (fragment && currentNode != markEnd) {
         // cleaning of remnants within the fragment
         while (currentNode != markEnd) {
-            let r = currentNode;
+            const nodeToRemove = currentNode;
             currentNode = currentNode.nextSibling;
-            r.remove();
+            nodeToRemove.remove();
         }
     }
 
@@ -386,11 +387,11 @@ export function renderChildren(children, fragment, parent, id, hydrate, isSvg) {
  * @param {import("vnode").Handlers} handlers
  **/
 export function diffProps(node, props, nextProps, handlers, isSvg) {
-    for (let key in props) {
+    for (const key in props) {
         !(key in nextProps) &&
             setProperty(node, key, props[key], null, isSvg, handlers);
     }
-    for (let key in nextProps) {
+    for (const key in nextProps) {
         setProperty(node, key, props[key], nextProps[key], isSvg, handlers);
     }
 }
@@ -435,16 +436,16 @@ export function setProperty(node, key, prevValue, nextValue, isSvg, handlers) {
          * @todo Find out why Element defines style at the type level
          * @type {any}
          */
-        let { style } = node;
+        const { style } = node;
 
         prevValue = prevValue || "";
         nextValue = nextValue || "";
 
-        let prevIsObject = isObject(prevValue);
-        let nextIsObject = isObject(nextValue);
+        const prevIsObject = isObject(prevValue);
+        const nextIsObject = isObject(nextValue);
 
         if (prevIsObject) {
-            for (let key in prevValue) {
+            for (const key in prevValue) {
                 if (nextIsObject) {
                     !(key in nextValue) && setPropertyStyle(style, key, null);
                 } else {
@@ -454,8 +455,8 @@ export function setProperty(node, key, prevValue, nextValue, isSvg, handlers) {
         }
 
         if (nextIsObject) {
-            for (let key in nextValue) {
-                let value = nextValue[key];
+            for (const key in nextValue) {
+                const value = nextValue[key];
                 if (prevIsObject && prevValue[key] === value) continue;
                 setPropertyStyle(style, key, value);
             }
@@ -463,7 +464,7 @@ export function setProperty(node, key, prevValue, nextValue, isSvg, handlers) {
             style.cssText = nextValue;
         }
     } else {
-        let attr = key[0] == "$" ? key.slice(1) : key;
+        const attr = key[0] == "$" ? key.slice(1) : key;
         if (
             attr === key &&
             ((!isSvg && !PROPS_AS_ATTRS[key] && key in node) ||
@@ -502,7 +503,7 @@ export function setEvent(node, type, nextHandler, handlers) {
         // create the subscriber if it does not exist
         if (!handlers[type]) {
             //the event configuration is only subscribed at the time of association
-            let options =
+            const options =
                 nextHandler.capture || nextHandler.once || nextHandler.passive
                     ? Object.assign({}, nextHandler)
                     : null;

--- a/src/template.js
+++ b/src/template.js
@@ -5,6 +5,6 @@ import { h, $, render } from "./render.js";
  * @param {DocumentFragment} [base]
  * @returns {T}
  */
-export let template = (vnode, base = $.createElement("template").content) =>
+export const template = (vnode, base = $.createElement("template").content) =>
     //@ts-ignore
     render(h("host", null, vnode), base).children[0];

--- a/src/tests/context.test.js
+++ b/src/tests/context.test.js
@@ -35,9 +35,9 @@ describe("src/context", () => {
 
         expect(value).to.deep.equal({ value: "new value" });
 
-        hooks.cleanEffects()();
+        hooks.cleanEffects()()();
 
-        hooks.cleanEffects(1)();
+        hooks.cleanEffects(true)()();
     });
 
     it("useContext", () => {
@@ -49,8 +49,8 @@ describe("src/context", () => {
 
         expect(value).to.deep.equal({ value: "init value" });
 
-        hooks.cleanEffects()();
+        hooks.cleanEffects()()();
 
-        hooks.cleanEffects(1)();
+        hooks.cleanEffects(true)()();
     });
 });

--- a/src/tests/core.test.js
+++ b/src/tests/core.test.js
@@ -30,6 +30,7 @@ describe("src/core", () => {
             "useAsync",
             "useSuspense",
             "createContext",
+            "useId",
             "useInsertionEffect",
             "Fragment"
         );

--- a/src/tests/core.test.js
+++ b/src/tests/core.test.js
@@ -1,34 +1,37 @@
-// import { expect } from "@esm-bundle/chai";
-// import * as core from "../core.js";
+import { expect } from "@esm-bundle/chai";
+import * as core from "../core.js";
 
-// describe("src/core", () => {
-//     it("core export", () => {
-//         expect(core).to.have.keys(
-//             "c",
-//             "h",
-//             "css",
-//             "render",
-//             "useState",
-//             "useLayoutEffect",
-//             "useEffect",
-//             "useProp",
-//             "useHost",
-//             "useEvent",
-//             "usePromise",
-//             "useMemo",
-//             "useCallback",
-//             "useRef",
-//             "useReducer",
-//             "useUpdate",
-//             "useHook",
-//             "Mark",
-//             "PropError",
-//             "Any",
-//             "options",
-//             "template",
-//             "useContext",
-//             "createContext",
-//             "Fragment"
-//         );
-//     });
-// });
+describe("src/core", () => {
+    it("core export", () => {
+        expect(core).to.have.keys(
+            "c",
+            "h",
+            "css",
+            "render",
+            "useState",
+            "useLayoutEffect",
+            "useEffect",
+            "useProp",
+            "useHost",
+            "useEvent",
+            "usePromise",
+            "useMemo",
+            "useCallback",
+            "useRef",
+            "useReducer",
+            "useUpdate",
+            "useHook",
+            "Mark",
+            "PropError",
+            "Any",
+            "options",
+            "template",
+            "useContext",
+            "useAsync",
+            "useSuspense",
+            "createContext",
+            "useInsertionEffect",
+            "Fragment"
+        );
+    });
+});

--- a/src/tests/core.test.js
+++ b/src/tests/core.test.js
@@ -1,34 +1,34 @@
-import { expect } from "@esm-bundle/chai";
-import * as core from "../core.js";
+// import { expect } from "@esm-bundle/chai";
+// import * as core from "../core.js";
 
-describe("src/core", () => {
-    it("core export", () => {
-        expect(core).to.have.keys(
-            "c",
-            "h",
-            "css",
-            "render",
-            "useState",
-            "useLayoutEffect",
-            "useEffect",
-            "useProp",
-            "useHost",
-            "useEvent",
-            "usePromise",
-            "useMemo",
-            "useCallback",
-            "useRef",
-            "useReducer",
-            "useUpdate",
-            "useHook",
-            "Mark",
-            "PropError",
-            "Any",
-            "options",
-            "template",
-            "useContext",
-            "createContext",
-            "Fragment"
-        );
-    });
-});
+// describe("src/core", () => {
+//     it("core export", () => {
+//         expect(core).to.have.keys(
+//             "c",
+//             "h",
+//             "css",
+//             "render",
+//             "useState",
+//             "useLayoutEffect",
+//             "useEffect",
+//             "useProp",
+//             "useHost",
+//             "useEvent",
+//             "usePromise",
+//             "useMemo",
+//             "useCallback",
+//             "useRef",
+//             "useReducer",
+//             "useUpdate",
+//             "useHook",
+//             "Mark",
+//             "PropError",
+//             "Any",
+//             "options",
+//             "template",
+//             "useContext",
+//             "createContext",
+//             "Fragment"
+//         );
+//     });
+// });

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@
  * @returns {boolean}
  */
 export function isEqualArray(before, after) {
-    let length = before.length;
+    const length = before.length;
     if (length !== after.length) return false;
     for (let i = 0; i < length; i++) {
         if (before[i] !== after[i]) return false;
@@ -20,24 +20,24 @@ export function isEqualArray(before, after) {
 }
 /**
  * Determine if the value is considered a function
- * @param {any} value
+ * @type {import("internal/utils").IsFunction}
  */
-export let isFunction = (value) => typeof value == "function";
+export const isFunction = (value) => typeof value == "function";
 
 /**
  * Determines if the value is considered an object
  * @param {any} value
  */
-export let isObject = (value) => typeof value == "object";
+export const isObject = (value) => typeof value == "object";
 
-export let { isArray } = Array;
+export const { isArray } = Array;
 
 /**
  *
  * @param {Element & {dataset?:object}} node
  * @returns
  */
-export let isHydrate = (node) => "hydrate" in (node?.dataset || {});
+export const isHydrate = (node) => "hydrate" in (node?.dataset || {});
 
 /**
  * @template {any[]} T
@@ -81,3 +81,14 @@ export function flat(list, callback) {
 
     if (last != null) callback(last);
 }
+
+/**
+ *
+ * @param {Element} target
+ * @param {string} type
+ * @param {(event:Event)=>void} handler
+ */
+export const addListener = (target, type, handler) => {
+    target.addEventListener(type, handler);
+    return () => target.removeEventListener(type, handler);
+};

--- a/ssr/load.js
+++ b/ssr/load.js
@@ -7,6 +7,8 @@ import { isServer } from "./utils.js";
 
 const ONCE = new Set();
 
+let ID = 0;
+
 if (isServer()) setOptions(options);
 
 /**
@@ -72,7 +74,7 @@ function setOptions(options) {
                                     ""
                                 )
                         );
-                        attrs.dataHydrate = true;
+                        attrs.dataHydrate = "s" + ID++;
                     }
                 } catch (e) {
                     console.log(e);

--- a/ssr/tests/src.test.js
+++ b/ssr/tests/src.test.js
@@ -3,7 +3,7 @@
 
     it("SSR", async () => {
         const root = document.createElement("div");
-        root.innerHTML = `<component-1 data-hydrate class="random" >1 2 3<button>ok</button><component-2 data-hydrate count="10" ><template shadowroot="open" ><button>increment</button><span>10</span><button>decrement</button></template></component-2><a data-hydrate count="0" data="{&quot;ok&quot;:1}" is="component-3" ><button>increment</button><span>0</span><button>decrement</button></a><component-4 data-hydrate count="100" ><template shadowroot="open" ><button>Increment</button><h1>100</h1><button>Decrement</button><style data-hydrate>
+        root.innerHTML = `<component-1 data-hydrate="s3" class="random" >1 2 3<button>ok</button><component-2 data-hydrate="s0" count="10" ><template shadowroot="open" ><button>increment</button><span>10</span><button>decrement</button></template></component-2><a data-hydrate="s1" count="0" data="{&quot;ok&quot;:1}" is="component-3" ><button>increment</button><span>0</span><button>decrement</button></a><component-4 data-hydrate="s2" count="100" ><template shadowroot="open" ><button>Increment</button><h1>100</h1><button>Decrement</button><style data-hydrate>
     :host {
         display: block;
         padding: 1rem;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
       "src/**/*", 
       "types/**/*",
   ],
-  "exclude": ["src/**/tests/","tests/"],
+  // "exclude": ["src/**/tests/","tests/"],
   "compilerOptions": {
     "strict": false,
     "noUnusedLocals": true,
@@ -13,16 +13,19 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "node",
+    "allowSyntheticDefaultImports":true,
     "allowJs": true,
     "declaration": true,
     "noEmit": true,
     "lib": ["ESNext", "DOM","DOM.Iterable"],
     "paths":{
       "core":["./types/core.d.ts"],
+      "hooks":["./types/hooks.d.ts"],
       "dom":["./types/dom.d.ts"],
       "component":["./types/component.d.ts"],
       "context":["./types/context.d.ts"],
-      "vnode":["./types/vnode.d.ts"]
+      "vnode":["./types/vnode.d.ts"],
+      "internal/*":["./types/internal/*"],
     },
   }
 }

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -1,11 +1,21 @@
 import { Component, CreateElement } from "./component";
 
-export type context<Value> = Component<
+export type DispatchConnectContext = (detail: DetailConnectContext) => any;
+
+export type DetailConnectContext = {
+    id: Context<any>;
+    connect(value: Context<any>): void;
+};
+
+export type ComponentContext<Value> = Component<
     { value: Value },
     { onUpdatedContext: Event }
 >;
 
-export type Context<Value> = CreateElement<context<Value>, HTMLElement> & {
+export type Context<Value> = CreateElement<
+    ComponentContext<Value>,
+    HTMLElement
+> & {
     value: Value;
 };
 
@@ -18,3 +28,9 @@ export type UseContext = <AtomicoContext extends Context<any>>(
 export const useContext: UseContext;
 
 export const createContext: CreateContext;
+
+export type UseProvider = (id: Context<any>, value: any) => void;
+
+export type ReturnUseConsumer<Value> = Value;
+
+export type UseConsumer = (id: Context<any>) => any;

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -195,6 +195,8 @@ export const useSuspense: Hooks.UseSuspense;
 
 export const useInsertionEffect: Hooks.UseInsertionEffect;
 
+export const useId: Hooks.UseId;
+
 export interface Options {
     sheet: boolean;
     ssr?: boolean;

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -189,6 +189,12 @@ export const useHook: Hooks.UseHook;
  */
 export const usePromise: Hooks.UsePromise;
 
+export const useAsync: Hooks.UseAsync;
+
+export const useSuspense: Hooks.UseSuspense;
+
+export const useInsertionEffect: Hooks.UseInsertionEffect;
+
 export interface Options {
     sheet: boolean;
     ssr?: boolean;

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -309,6 +309,10 @@ export interface Atomico<Props, Base> extends AtomicoStatic<Props> {
     ): AtomicoThis<Props, Base>;
 }
 
+/**
+ * This type allows retrieving the parameters of a customElement
+ * to be reflected in the JSX by third party APIs, eg: `@atomico/react`.
+ */
 export type JSXElement<Base extends FillConstructor> =
     Base extends AtomicoStatic<any>
         ? Base extends { new (props?: infer Props): any }

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -327,6 +327,6 @@ export type JSXElement<Base extends FillConstructor> =
  */
 export interface JSX<Props = {}, Base = HTMLElement> extends Element {
     new (
-        props?: JSXProxy<DOMTag<DOMThis<Base>, Props>, DOMThis<Props>>
-    ): DOMThis<Props>;
+        props?: JSXProxy<DOMTag<DOMThis<Base>, Props>, Base>
+    ): PropsNullable<Props> & DOMThis<Base>;
 }

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -19,7 +19,7 @@ type SetState<State> = (state: State | ((reduce: State) => State)) => void;
 /**
  * Used by UseProp and UseState, construct return types
  */
-type ReturnUseState<Value> = [Value, SetState<Value>];
+export type ReturnUseState<Value> = [Value, SetState<Value>];
 
 export type UseState = <OptionalInitialState = any>(
     initialState?: OptionalInitialState
@@ -77,7 +77,7 @@ type SetProp<State> = (
 /**
  * Used by UseProp and UseState, construct return types
  */
-type ReturnUseProp<Value> = [Value | undefined, SetProp<Value>];
+export type ReturnUseProp<Value> = [Value | undefined, SetProp<Value>];
 
 export type UseProp = <T = any>(
     prop: string
@@ -90,14 +90,11 @@ export type UseProp = <T = any>(
  */
 export type UseHook = <Render extends (arg?: any) => any>(
     render: Render,
-    layoutEffect?: (
-        value: ReturnType<Render>,
-        unmounted: boolean
-    ) => ReturnType<Render>,
     effect?: (
         value: ReturnType<Render>,
         unmounted: boolean
-    ) => ReturnType<Render>
+    ) => ReturnType<Render>,
+    tag?: symbol
 ) => ReturnType<Render>;
 
 /**
@@ -109,22 +106,37 @@ export type UseHost = <Current = AtomicoThis>() => Required<Ref<Current>>;
 
 export type UseUpdate = () => () => void;
 
+export type ReturnPromise<result> =
+    | {
+          pending: true;
+          fulfilled?: false;
+          rejected?: false;
+          result?: never;
+      }
+    | {
+          fulfilled: true;
+          result: result;
+          rejected?: false;
+          pending?: false;
+      }
+    | {
+          rejected: true;
+          pending?: false;
+          fulfilled?: false;
+          result?: unknown;
+      }
+    | {
+          rejected?: undefined;
+          pending?: undefined;
+          fulfilled?: undefined;
+          result?: undefined;
+      };
+
 export type UsePromise = <Callback extends (...args: any[]) => Promise<any>>(
     callback: Callback,
     args: Parameters<Callback>,
     autorun?: boolean
-) =>
-    | {
-          pending: true;
-          fulfilled: false;
-          result: never;
-      }
-    | {
-          pending: false;
-          fulfilled: true;
-          result: Awaited<ReturnType<Callback>>;
-      }
-    | { rejected: true; pending: false; fulfilled: false; result: never };
+) => ReturnPromise<Awaited<ReturnType<Callback>>>;
 
 /**
  * UseReducer

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -43,6 +43,11 @@ export type UseEffect = <Effect extends () => void | (() => any)>(
 export type UseLayoutEffect = UseEffect;
 
 /**
+ * UseLayoutEffect
+ */
+export type UseInsertionEffect = UseEffect;
+
+/**
  * UseMemo
  */
 export type UseMemo = <CallbackMemo extends () => any>(
@@ -182,6 +187,9 @@ export type ReturnUseSuspense =
           rejected?: true;
       };
 
-export type UseSuspense = () => ReturnUseSuspense;
+/**
+ * @param fps - allows to delay in FPS the update of states
+ */
+export type UseSuspense = (fps?: number) => ReturnUseSuspense;
 
 export type UseAsync = UsePromise;

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -164,3 +164,24 @@ export type UseReducer = <
             : any
     ) => void
 ];
+
+export type ReturnUseSuspense =
+    | {
+          pending: true;
+          fulfilled?: false;
+          rejected?: false;
+      }
+    | {
+          pending?: false;
+          fulfilled: true;
+          rejected?: false;
+      }
+    | {
+          pending?: false;
+          fulfilled?: false;
+          rejected?: true;
+      };
+
+export type UseSuspense = () => ReturnUseSuspense;
+
+export type UseAsync = UsePromise;

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -192,7 +192,10 @@ export type ReturnUseSuspense =
  */
 export type UseSuspense = (fps?: number) => ReturnUseSuspense;
 
-export type UseAsync = UsePromise;
+export type UseAsync = <Callback extends (...args: any[]) => Promise<any>>(
+    callback: Callback,
+    args: Parameters<Callback>
+) => Awaited<ReturnType<Callback>>;
 
 /**
  * Returns an ID as a string, this ID can have 2 prefixes

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -193,3 +193,14 @@ export type ReturnUseSuspense =
 export type UseSuspense = (fps?: number) => ReturnUseSuspense;
 
 export type UseAsync = UsePromise;
+
+/**
+ * Returns an ID as a string, this ID can have 2 prefixes
+ * `s`erver and `c`lient
+ * @example
+ * ```tsx
+ * const id = useId();
+ * <input id={id}/>
+ * ```
+ */
+export type UseId = () => string;

--- a/types/internal/hooks.d.ts
+++ b/types/internal/hooks.d.ts
@@ -1,0 +1,64 @@
+export type Effect = (state: any, unmounted?: boolean) => any;
+
+export type Hook = {
+    value?: any;
+    effect?: Effect;
+    tag?: symbol | string | number;
+};
+
+/**
+ * Map of states associated with an increasing position
+ */
+export type Hooks = {
+    [i: number]: Hook;
+};
+
+export type SCOPE = {
+    i: number;
+    hooks: Hooks;
+    host: any;
+    update: any;
+};
+
+export type Load = <Callback extends () => any>(
+    callback: Callback
+) => ReturnType<Callback>;
+
+/**
+ * clean all useEffects
+ */
+export type CleanUseEffects = () => void;
+
+/**
+ * clean all useLayoutEffect
+ */
+export type CleanUseLayoutEffects = () => CleanUseEffects;
+
+/**
+ * allows to clean the effects step by step,
+ * first execution of the callback cleans the useInsertionEffect,
+ * second execution of return of the previous callback cleans the useLayoutEffect and
+ * the last execution of the previous return cleans the useEffect
+ */
+export type CleanEffects = (unmounted?: boolean) => CleanUseLayoutEffects;
+
+export type CreateHooks = (
+    update?: () => any,
+    host?: any
+) => {
+    load: Load;
+    cleanEffects: CleanEffects;
+};
+
+export type CollectorCallback = (() => {}) | null | true;
+
+export type CollectorArgs = any[];
+
+export type CollectorEffect = (
+    params?: [CollectorCallback, CollectorArgs] | []
+) => [CollectorCallback, CollectorArgs];
+
+export type UseAnyEffect = <Effect extends () => void | (() => any)>(
+    effect: Effect,
+    args?: any[]
+) => void;

--- a/types/internal/hooks.d.ts
+++ b/types/internal/hooks.d.ts
@@ -17,7 +17,7 @@ export type Hooks = {
 
 export type SCOPE = {
     i: number;
-    id: number;
+    id: number | string;
     hooks: Hooks;
     host: any;
     update: any;
@@ -48,7 +48,7 @@ export type CleanEffects = (unmounted?: boolean) => CleanUseLayoutEffects;
 export type CreateHooks = (
     update?: () => any,
     host?: any,
-    id?: number
+    id?: number | string
 ) => {
     load: Load;
     cleanEffects: CleanEffects;

--- a/types/internal/hooks.d.ts
+++ b/types/internal/hooks.d.ts
@@ -1,3 +1,5 @@
+import { ReturnUseState, ReturnUseSuspense } from "hooks";
+
 export type Effect = (state: any, unmounted?: boolean) => any;
 
 export type Hook = {
@@ -62,3 +64,5 @@ export type UseAnyEffect = <Effect extends () => void | (() => any)>(
     effect: Effect,
     args?: any[]
 ) => void;
+
+export type ReturnSetStateUseSuspense = ReturnUseState<ReturnUseSuspense>;

--- a/types/internal/hooks.d.ts
+++ b/types/internal/hooks.d.ts
@@ -17,6 +17,7 @@ export type Hooks = {
 
 export type SCOPE = {
     i: number;
+    id: number;
     hooks: Hooks;
     host: any;
     update: any;
@@ -46,7 +47,8 @@ export type CleanEffects = (unmounted?: boolean) => CleanUseLayoutEffects;
 
 export type CreateHooks = (
     update?: () => any,
-    host?: any
+    host?: any,
+    id?: number
 ) => {
     load: Load;
     cleanEffects: CleanEffects;

--- a/types/internal/utils.d.ts
+++ b/types/internal/utils.d.ts
@@ -1,0 +1,1 @@
+export type IsFunction = (param: any) => param is (...args: any[]) => any;

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,6 @@
-let W = window;
+const W = window;
 
-let COMPATIBILITY_LIST = [
+const COMPATIBILITY_LIST = [
     ["customElements", W],
     ["ShadowRoot", W],
     ["Map", W],
@@ -15,13 +15,13 @@ let COMPATIBILITY_LIST = [
  * @param  {...any} args
  * @returns {string}
  */
-export let serialize = (...args) => args.filter((value) => value).join(" ");
+export const serialize = (...args) => args.filter((value) => value).join(" ");
 
 /**
  * check the features that Atomico leverages the browser
  * @returns {string[]}
  */
-export let checkIncompatibility = () =>
+export const checkIncompatibility = () =>
     COMPATIBILITY_LIST
         //@ts-ignore
         .map(([check, ctx]) => (!ctx || !(check in ctx) ? check : 0))


### PR DESCRIPTION
This PR refactors part of the Atomico code, to introduce **new features** and **maintenance improvements**.

## new features.

1. The hooks api has been refactored to now allow hooks to be tagged, thanks to this tag in the future it will be possible to filter the execution of hooks and improve their inspection, currently this functionality is being used by the new `useInsertionEffect` hook.
2. in the previous version it introduced use Promise as an advance to asynchronous handling within the core, this hook has allowed us to add in this version 2 new hooks `useAsync` and `useSuspense`.
3. se agrega `useId`, con soporte tanto al usar SSR o Browser.

### useInsertionEffect

copy of React's useInsertionEffect, similar to useEffect, but this hook is executed before rendering the DOM, this hook is useful for 3rd party apis looking to manipulate the DOM before rendering the component's DOM.

### useId

copy of React's useId, creates a unique ID for the Atomico context, the generated ID will depend on the origin, whether it is SSR or Client.

SSR ID Example: `s0-1`.
CLIENT ID Example: `c0-1`.

### useAsync y useSuspense

**useAsync**: this hook is a step before the adoption of React's `use` hook, it allows to suspend the rendering execution of the webcomponent and to communicate to `useSuspense` the execution suspension.

```tsx
const getUser = (id: number): Promise<{ name: string }> =>
  fetch(`user/${id}`).then((res) => res.json());

function component({ id }) {
  const user = useAsync(getUser, [id]);
  return <host>{user.name}</host>;
}
```

**Nota 1**: This hook conditions the execution of the promise according to a list of optional arguments, which allows the promise to be regenerated every time the list changes.

**Nota 2**: `useAsync` suspends rendering execution and resumes it only if the promise has been resolved or rejected.

**useSuspense**: captures all nested executions that have been paused, it returns an object that defines the state of the executions.

```jsx
function component() {
  const status = useSuspense();
  return (
    <host shadowDom>
      {status.pending ? "Loading..." : status.fulfilled ? "Done!" : "Error!"}~
      <slot />
    </host>
  );
}
```

## Maintenance improvements

1. migration of the use of let by const, to improve the maintenance syntax within core.
2. deleveraging of the context api internally.
3. migration of types from JSDOC to JSDOC with TS.

## Warnings

This new change has generated modifications to the core at the level of hooks, currently the changes have passed all the tests without complications, we will be attentive to any bug or unexpected behavior.

For creators of third party APIs based on createHooks, cleanEffects now has 3 execution steps:

1. The first run clears the effects of `useInsertionEffects`.
2. The second run clears the effects of `useLayoutEffects`.
3. The third and last run clears the effects of `useEffect`.
    You should update your tests by adding the third run to clean up the useEffect, example:

```js
hooks.cleanEffects()()();
```
