### PR TITLE
V1.73.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "atomico",
-    "version": "1.71.2",
+    "version": "1.72.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "atomico",
-            "version": "1.71.2",
+            "version": "1.72.0",
             "license": "MIT",
             "devDependencies": {
                 "@esm-bundle/chai": "^4.3.4-fix.0",

--- a/package.json
+++ b/package.json
@@ -5,25 +5,47 @@
     "type": "module",
     "main": "./core.js",
     "module": "./core.js",
-    "source": "./core.js",
     "types": "./types/core.d.ts",
     "exports": {
-        ".": "./core.js",
-        "./core": "./src/core.js",
-        "./test-hooks": "./test-hooks.js",
-        "./test-dom": "./test-dom.js",
-        "./jsx-runtime": "./jsx-runtime.js",
-        "./jsx-dev-runtime": "./jsx-runtime.js",
-        "./utils": "./utils.js",
-        "./html": "./html.js",
-        "./ssr": "./ssr.js",
-        "./ssr/load": "./ssr/load.js"
+        ".": {
+            "types": "./types/core.d.ts",
+            "default": "./core.js"
+        },
+        "./test-hooks": {
+            "types": "./types/test-hooks.d.ts",
+            "default": "./test-hooks.js"
+        },
+        "./test-dom": {
+            "types": "./types/test-dom.d.ts",
+            "default": "./test-dom.js"
+        },
+        "./jsx-runtime": {
+            "types": "./types/jsx-runtime.d.ts",
+            "default": "./jsx-runtime.js"
+        },
+        "./jsx-dev-runtime": {
+            "types": "./types/jsx-runtime.d.ts",
+            "default": "./jsx-runtime.js"
+        },
+        "./utils": {
+            "types": "./types/utils.d.ts",
+            "default": "./utils.js"
+        },
+        "./html": {
+            "types": "./types/html.d.ts",
+            "default": "./html.js"
+        },
+        "./ssr": {
+            "types": "./types/ssr.d.ts",
+            "default": "./ssr.js"
+        },
+        "./ssr/load": {
+            "types": "./types/ssr-load.d.ts",
+            "default": "./ssr/load.js"
+        }
     },
     "typesVersions": {
         "*": {
-            "core": [
-                "types/core.d.ts"
-            ],
             "html": [
                 "types/html.d.ts"
             ],

--- a/src/element/custom-element.js
+++ b/src/element/custom-element.js
@@ -1,8 +1,8 @@
-import { setPrototype, transformValue } from "./set-prototype.js";
 import { createHooks } from "../hooks/create-hooks.js";
-export { Any } from "./set-prototype.js";
 import { flat, isHydrate } from "../utils.js";
 import { ParseError } from "./errors.js";
+import { setPrototype, transformValue } from "./set-prototype.js";
+export { Any, createType } from "./set-prototype.js";
 
 let ID = 0;
 /**

--- a/src/element/set-prototype.js
+++ b/src/element/set-prototype.js
@@ -136,7 +136,8 @@ export const transformValue = (type, value) =>
         ? Number(value)
         : type == Array || type == Object
         ? JSON.parse(value)
-        : new type(value);
+        : // TODO: If when defining reflect the prop can also be of type string?
+          new type(value);
 /**
  * Filter the values based on their type
  * @param {any} type

--- a/src/element/set-prototype.js
+++ b/src/element/set-prototype.js
@@ -1,5 +1,7 @@
-import { isObject, isFunction } from "../utils.js";
+import { isFunction, isObject } from "../utils.js";
 import { PropError } from "./errors.js";
+
+export const CUSTOM_TYPE_NAME = "Custom";
 /**
  * The Any type avoids the validation of prop types
  * @type {null}
@@ -28,9 +30,13 @@ export function setPrototype(prototype, prop, schema, attrs, values) {
         event,
         value: defaultValue,
         attr = getAttr(prop),
-    } = isObject(schema) && schema != Any ? schema : { type: schema };
+    } = schema?.name != CUSTOM_TYPE_NAME && isObject(schema) && schema != Any
+        ? schema
+        : { type: schema };
 
-    const isCallable = !(type == Function || type == Any);
+    const isCustomType = type?.name === CUSTOM_TYPE_NAME && type.map;
+
+    const isCallable = !(type == Function || isCustomType || type == Any);
 
     const withDefaultValue = defaultValue != null;
     const withDefaultValueAlways = withDefaultValue && type != Boolean;
@@ -47,12 +53,13 @@ export function setPrototype(prototype, prop, schema, attrs, values) {
             if (withDefaultValueAlways && newValue == null)
                 newValue = defaultValue;
 
-            const { error, value } = filterValue(
+            const { error, value } = (isCustomType ? mapValue : filterValue)(
                 type,
                 isCallable && isFunction(newValue)
                     ? newValue(oldValue)
                     : newValue
             );
+
             if (error && value != null) {
                 throw new PropError(
                     this,
@@ -123,7 +130,9 @@ export const reflectValue = (host, type, attr, value) =>
         ? host.removeAttribute(attr)
         : host.setAttribute(
               attr,
-              isObject(value)
+              type?.name === CUSTOM_TYPE_NAME && type?.serialize
+                  ? type?.serialize(value)
+                  : isObject(value)
                   ? JSON.stringify(value)
                   : type == Boolean
                   ? ""
@@ -145,8 +154,24 @@ export const transformValue = (type, value) =>
         ? value
         : type == Array || type == Object
         ? JSON.parse(value)
+        : type.name == CUSTOM_TYPE_NAME
+        ? value
         : // TODO: If when defining reflect the prop can also be of type string?
           new type(value);
+
+/**
+ *
+ * @param {import("schema").TypeCustom<(...args:any)=>any>} TypeCustom
+ * @param {*} value
+ * @returns
+ */
+export const mapValue = ({ map }, value) => {
+    try {
+        return { value: map(value), error: false };
+    } catch {
+        return { value, error: true };
+    }
+};
 /**
  * Filter the values based on their type
  * @param {any} type
@@ -175,6 +200,17 @@ export const filterValue = (type, value) =>
                       : typeof value != "boolean",
           }
         : { value, error: true };
+
+/**
+ * @param {(...args:any[])=>any} map
+ * @param {(...args:any[])=>any} [serialize]
+ * @returns {import("schema").TypeCustom<(...args:any)=>any>}
+ */
+export const createType = (map, serialize) => ({
+    name: CUSTOM_TYPE_NAME,
+    map,
+    serialize,
+});
 /**
  * Type any, used to avoid type validation.
  * @typedef {null} Any

--- a/src/element/set-prototype.js
+++ b/src/element/set-prototype.js
@@ -141,6 +141,8 @@ export const transformValue = (type, value) =>
         ? !!TRUE_VALUES[value]
         : type == Number
         ? Number(value)
+        : type == String
+        ? value
         : type == Array || type == Object
         ? JSON.parse(value)
         : // TODO: If when defining reflect the prop can also be of type string?

--- a/src/element/set-prototype.js
+++ b/src/element/set-prototype.js
@@ -136,7 +136,7 @@ export const transformValue = (type, value) =>
         ? Number(value)
         : type == Array || type == Object
         ? JSON.parse(value)
-        : value;
+        : new type(value);
 /**
  * Filter the values based on their type
  * @param {any} type

--- a/src/element/set-prototype.js
+++ b/src/element/set-prototype.js
@@ -26,11 +26,14 @@ export function setPrototype(prototype, prop, schema, attrs, values) {
         type,
         reflect,
         event,
-        value,
+        value: defaultValue,
         attr = getAttr(prop),
     } = isObject(schema) && schema != Any ? schema : { type: schema };
 
     const isCallable = !(type == Function || type == Any);
+
+    const withDefaultValue = defaultValue != null;
+    const withDefaultValueAlways = withDefaultValue && type != Boolean;
 
     Object.defineProperty(prototype, prop, {
         configurable: true,
@@ -40,6 +43,10 @@ export function setPrototype(prototype, prop, schema, attrs, values) {
          */
         set(newValue) {
             const oldValue = this[prop];
+
+            if (withDefaultValueAlways && newValue == null)
+                newValue = defaultValue;
+
             const { error, value } = filterValue(
                 type,
                 isCallable && isFunction(newValue)
@@ -82,7 +89,7 @@ export function setPrototype(prototype, prop, schema, attrs, values) {
         },
     });
 
-    if (value != null) values[prop] = value;
+    if (withDefaultValue) values[prop] = defaultValue;
 
     attrs[attr] = { prop, type };
 }

--- a/src/hooks/create-hooks.js
+++ b/src/hooks/create-hooks.js
@@ -1,4 +1,4 @@
-const ID = Symbol.for("atomico/scope");
+const ID = Symbol.for("atomico/hooks");
 
 // previene la perdida de hook concurrente al duplicar el modulo
 // This usually happens on Deno and Webpack

--- a/src/hooks/custom-hooks.js
+++ b/src/hooks/custom-hooks.js
@@ -2,3 +2,4 @@ export * from "./custom-hooks/use-prop.js";
 export * from "./custom-hooks/use-event.js";
 export * from "./custom-hooks/use-promise.js";
 export * from "./custom-hooks/use-suspense.js";
+export * from "./custom-hooks/use-abort-controller.js";

--- a/src/hooks/custom-hooks/use-abort-controller.js
+++ b/src/hooks/custom-hooks/use-abort-controller.js
@@ -1,0 +1,12 @@
+import { useMemo, useEffect } from "../hooks.js";
+
+/**
+ * @type {import("core").UseAbortController}
+ */
+export const useAbortController = (args) => {
+    const abortController = useMemo(() => new AbortController(), args);
+
+    useEffect(() => () => abortController.abort(), [abortController]);
+
+    return abortController;
+};

--- a/src/hooks/custom-hooks/use-promise.js
+++ b/src/hooks/custom-hooks/use-promise.js
@@ -22,7 +22,13 @@ export const usePromise = (callback, args, autorun = true) => {
 
             callback(...currentArgs).then(
                 (result) => !cancel && setState({ result, fulfilled: true }),
-                (result) => !cancel && setState({ result, rejected: true })
+                (result) =>
+                    !cancel &&
+                    setState(
+                        result?.name === "AbortError"
+                            ? { result, aborted: true }
+                            : { result, rejected: true }
+                    )
             );
 
             return () => (cancel = true);

--- a/src/hooks/tests/use-promise.test.js
+++ b/src/hooks/tests/use-promise.test.js
@@ -1,6 +1,7 @@
 import { expect } from "@esm-bundle/chai";
 import { createHooks } from "../create-hooks.js";
 import { usePromise } from "../custom-hooks/use-promise.js";
+import { useAbortController } from "../custom-hooks/use-abort-controller.js";
 
 describe("usePromise", () => {
     it("fulfilled", (done) => {
@@ -35,6 +36,40 @@ describe("usePromise", () => {
         let cycle = 0;
 
         const load = () => {
+            const controller = useAbortController([]);
+            const promise = usePromise(
+                () => fetch("any", { signal: controller.signal }),
+                []
+            );
+            controller.abort();
+            switch (cycle++) {
+                case 0:
+                    expect(promise).to.deep.equal({ pending: true });
+                    break;
+
+                case 1:
+                    expect(promise).to.deep.equal({
+                        result: promise.result,
+                        aborted: true,
+                    });
+                    done();
+                    break;
+            }
+        };
+
+        const render = () => hooks.load(load);
+
+        const hooks = createHooks(render);
+
+        render();
+
+        hooks.cleanEffects()()();
+    });
+    it("aborted", (done) => {
+        let cycle = 0;
+
+        const load = () => {
+            useAbortController();
             const promise = usePromise(() => Promise.reject(10), []);
             switch (cycle++) {
                 case 0:

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,10 @@
+const ID = Symbol.for("atomico/options");
+
+globalThis[ID] = globalThis[ID] || {
+    sheet: !!document.adoptedStyleSheets,
+};
+
 /**
  * @type {import("core").Options}
  */
-export const options = {
-    //@ts-ignore
-    sheet: !!document.adoptedStyleSheets,
-};
+export const options = globalThis[ID];

--- a/src/tests/core.test.js
+++ b/src/tests/core.test.js
@@ -31,6 +31,7 @@ describe("src/core", () => {
             "useContext",
             "useAsync",
             "useSuspense",
+            "useAbortController",
             "createContext",
             "createElement",
             "useId",

--- a/src/tests/core.test.js
+++ b/src/tests/core.test.js
@@ -34,6 +34,7 @@ describe("src/core", () => {
             "useAbortController",
             "createContext",
             "createElement",
+            "createType",
             "useId",
             "useInsertionEffect",
             "Fragment"

--- a/src/tests/create-type.test.js
+++ b/src/tests/create-type.test.js
@@ -1,0 +1,110 @@
+import { expect } from "@esm-bundle/chai";
+import { html } from "../../html.js";
+import { createType } from "../element/custom-element.js";
+import { customElementScope } from "./element.test.js";
+
+describe("src/element/create-type", () => {
+    it("createType", async () => {
+        const TypeAlwaysArray = createType((value) =>
+            Array.isArray(value) ? value : [value]
+        );
+
+        function component() {
+            return html`<host />`;
+        }
+
+        component.props = {
+            array: TypeAlwaysArray,
+        };
+
+        const instance = customElementScope(component);
+
+        document.body.append(instance);
+
+        instance.array = 10;
+
+        await instance.updated;
+
+        expect(instance.array).to.deep.equal([10]);
+    });
+    it("createType: schema", async () => {
+        const TypeAlwaysArray = createType((value) =>
+            Array.isArray(value) ? value : [value]
+        );
+
+        function component() {
+            return html`<host />`;
+        }
+
+        component.props = {
+            array: {
+                type: TypeAlwaysArray,
+            },
+        };
+
+        const instance = customElementScope(component);
+
+        document.body.append(instance);
+
+        instance.array = 10;
+
+        await instance.updated;
+
+        expect(instance.array).to.deep.equal([10]);
+    });
+    it("createType: schema serialize", async () => {
+        const TypeAlwaysArray = createType((value) =>
+            Array.isArray(value) ? value : [value]
+        );
+
+        function component() {
+            return html`<host />`;
+        }
+
+        component.props = {
+            array: {
+                type: TypeAlwaysArray,
+                reflect: true,
+            },
+        };
+
+        const instance = customElementScope(component);
+
+        document.body.append(instance);
+
+        instance.array = 10;
+
+        await instance.updated;
+
+        expect(instance.getAttribute("array")).to.deep.equal("[10]");
+    });
+    it("createType: schema custom serialize", async () => {
+        const toString = (value) => `data:${JSON.stringify(value)}`;
+
+        const TypeAlwaysArray = createType(
+            (value) => (Array.isArray(value) ? value : [value]),
+            toString
+        );
+
+        function component() {
+            return html`<host />`;
+        }
+
+        component.props = {
+            array: {
+                type: TypeAlwaysArray,
+                reflect: true,
+            },
+        };
+
+        const instance = customElementScope(component);
+
+        document.body.append(instance);
+
+        instance.array = 10;
+
+        await instance.updated;
+
+        expect(instance.getAttribute("array")).to.deep.equal(toString([10]));
+    });
+});

--- a/src/tests/element.test.js
+++ b/src/tests/element.test.js
@@ -6,6 +6,10 @@ import { html } from "../../html.js";
 import { options } from "../options.js";
 import { useState } from "../hooks/hooks.js";
 
+/**
+ *
+ * @returns {any}
+ */
 export function customElementScope(component, autoScope = true) {
     let scope = `w-${(Math.random() + "").slice(2)}`;
     customElements.define(scope, autoScope ? c(component) : component);
@@ -14,7 +18,9 @@ export function customElementScope(component, autoScope = true) {
 
 describe("src/element", () => {
     it("name", () => {
-        function myElement() {}
+        function myElement() {
+            return html`<host />`;
+        }
 
         myElement.props = {
             value: Number,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       "component":["./types/component.d.ts"],
       "context":["./types/context.d.ts"],
       "vnode":["./types/vnode.d.ts"],
+      "schema":["./types/schema.d.ts"],
       "internal/*":["./types/internal/*"],
     },
   }

--- a/types/component.d.ts
+++ b/types/component.d.ts
@@ -19,16 +19,16 @@ import { Sheets } from "./css";
  * component.props = {value:Number}
  * ```
  */
-type GetProps<P> = P extends {
+export type GetProps<P, JSX = null> = P extends {
     readonly "##props"?: infer P;
 }
     ? P
     : P extends { props: SchemaProps }
-    ? GetProps<P["props"]>
+    ? GetProps<P["props"], JSX>
     : {
-          [K in GetKeysWithConfigValue<P>]: GetPropType<P[K]>;
+          [K in GetKeysWithConfigValue<P>]: GetPropType<P[K], JSX>;
       } & {
-          [K in GetKeysWithoutConfigValue<P>]?: GetPropType<P[K]>;
+          [K in GetKeysWithoutConfigValue<P>]?: GetPropType<P[K], JSX>;
       };
 
 type GetKeysWithConfigValue<P> = {
@@ -47,7 +47,7 @@ type GetKeysWithoutConfigValue<P> = {
         : I;
 }[keyof P];
 
-type GetPropType<Value> = Value extends {
+type GetPropType<Value, JSX = null> = Value extends {
     type: infer T;
     value: infer V;
 }
@@ -57,16 +57,13 @@ type GetPropType<Value> = Value extends {
         ? T
         : V
     : Value extends { type: infer T }
-    ? ConstructorType<T>
+    ? ConstructorType<T, JSX>
     : Type<any> extends Value // Sometimes TS saturates, this verification limits the effort of TS to infer
     ? Value extends Type<infer R>
         ? R
-        : ConstructorType<Value>
-    : ConstructorType<Value>;
+        : ConstructorType<Value, JSX>
+    : ConstructorType<Value, JSX>;
 
-type ReplaceProps<P, Types> = {
-    [I in keyof P]?: I extends keyof Types ? Types[I] : P;
-};
 /**
  * Infers the props from the component's props object, example:
  * ### Syntax
@@ -94,11 +91,9 @@ type ReplaceProps<P, Types> = {
  *
  * ```
  */
-export type Props<P = null, Types = null> = P extends null
+export type Props<P = null, JSX = null> = P extends null
     ? SchemaProps
-    : Types extends null
-    ? GetProps<P>
-    : ReplaceProps<GetProps<P>, Types>;
+    : GetProps<P, JSX>;
 
 export type Component<Props = null, Meta = any> = Props extends null
     ? {
@@ -120,7 +115,7 @@ export type CreateElement<C, Base, CheckMeta = true> = CheckMeta extends true
         ? CreateElement<C & { props: SyntheticProps<Meta> }, Base, false>
         : CreateElement<C, Base, false>
     : C extends { props: infer P }
-    ? Atomico<Props<P>, Base>
+    ? Atomico<Props<P, true>, Base>
     : Atomico<{}, Base>;
 
 export type SyntheticProps<Props> = {

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -1,6 +1,6 @@
 import { JSXElements } from "./dom";
 
-import { TypeToConstructor } from "./schema";
+import { TypeToConstructor, TypeCustom } from "./schema";
 
 import * as Hooks from "./hooks";
 import { H, Render, VNodeRender } from "./vnode";
@@ -231,3 +231,9 @@ export function template<T = Element>(vnode: any): T;
  * Allows to declare the simple type of the Any type.
  */
 export const Any: null;
+
+export function createType<
+    Type,
+    Map extends (...args: any[]) => any = (...args: any[]) => Type,
+    ToString = (value: ReturnType<Map>) => string
+>(map: Map, toString?: ToString): TypeCustom<Map>;

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -193,6 +193,8 @@ export const usePromise: Hooks.UsePromise;
 
 export const useAsync: Hooks.UseAsync;
 
+export const useAbortController: Hooks.UseAbortController;
+
 export const useSuspense: Hooks.UseSuspense;
 
 export const useInsertionEffect: Hooks.UseInsertionEffect;

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -300,7 +300,7 @@ export type AtomicoThis<Props = {}, Base = HTMLElement> = PropsNullable<Props> &
     };
 
 export interface AtomicoStatic<Props> extends HTMLElement {
-    styles: Sheets;
+    styles: Sheets[];
     props: SchemaInfer<Props>;
     /**
      * Meta property, allows associating the component's

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -122,6 +122,10 @@ type DOMEventType<Type extends string, CurrentEvent> = {
     };
 };
 
+interface DOM$Attrs {
+    [prop: `\$${string}`]: Nullable<string>;
+}
+
 interface DOMUnknown {
     [prop: string]: any;
 }
@@ -192,6 +196,7 @@ export type DOMTag<Element, Props = null> = Props extends null
               DOMGenericProperties &
               DOMRef<Element>
       > &
+          DOM$Attrs &
           DOMUnknown
     : PropsNullable<
           Props &
@@ -199,6 +204,7 @@ export type DOMTag<Element, Props = null> = Props extends null
               DOMGenericProperties &
               DOMRef<Element & Props>
       > &
+          DOM$Attrs &
           DOMUnknown;
 
 type S = keyof null;

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -114,24 +114,35 @@ export type ReturnPromise<result> =
           pending: true;
           fulfilled?: false;
           rejected?: false;
+          aborted?: false;
           result?: never;
       }
     | {
           fulfilled: true;
           result: result;
           rejected?: false;
+          aborted?: false;
           pending?: false;
       }
     | {
           rejected: true;
           pending?: false;
           fulfilled?: false;
+          aborted?: false;
           result?: unknown;
+      }
+    | {
+          aborted: true;
+          result: DOMException;
+          rejected?: false;
+          pending?: false;
+          fulfilled?: false;
       }
     | {
           rejected?: undefined;
           pending?: undefined;
           fulfilled?: undefined;
+          aborted?: undefined;
           result?: undefined;
       };
 
@@ -194,6 +205,10 @@ export type UseAsync = <Callback extends (...args: any[]) => Promise<any>>(
     callback: Callback,
     args: Parameters<Callback>
 ) => Awaited<ReturnType<Callback>>;
+
+export type UseAbortController = <Args extends any[]>(
+    args: Args
+) => AbortController;
 
 /**
  * Returns an ID as a string, this ID can have 2 prefixes

--- a/types/tests/1-basic.tsx
+++ b/types/tests/1-basic.tsx
@@ -9,12 +9,14 @@ function myComponent({ value }: Props<typeof myComponent>): Host<{
 
 myComponent.props = {
     value: String,
+    value2: Array,
 };
 
 export const MyComponent = c(myComponent);
 
 <MyComponent
     value={"ok"}
+    value2={[]}
     onclick={() => {}}
     onChange={(event) => {
         event.detail.id++;

--- a/types/tests/23-property-auto-fill.tsx
+++ b/types/tests/23-property-auto-fill.tsx
@@ -1,0 +1,23 @@
+import { c, Props } from "core";
+
+function component({ value }: Props<typeof component>) {
+    return <host>{value * 2}</host>;
+}
+
+component.props = {
+    value: {
+        type: Number,
+        value: 0,
+    },
+};
+
+const Component = c(component);
+
+<Component
+    onclick={(event) => {
+        event.currentTarget.value;
+    }}
+    value={null}
+    message="welcome"
+    $message={null}
+></Component>;

--- a/types/tests/24-use-async.tsx
+++ b/types/tests/24-use-async.tsx
@@ -1,0 +1,9 @@
+import { useAsync, useAbortController } from "core";
+
+async function getUser(id: number, signal: AbortSignal) {
+    return fetch(`/id/${id}`, { signal });
+}
+
+const { signal } = useAbortController([1, true]);
+
+useAsync(getUser, [1, signal]);

--- a/types/tests/25-create-type.tsx
+++ b/types/tests/25-create-type.tsx
@@ -1,0 +1,18 @@
+import { Props, c, createType } from "core";
+
+function myComponent({ check }: Props<typeof myComponent>) {
+    return <host shadowDom>{check}</host>;
+}
+
+const TypeLoad = createType(
+    (value: number) => Promise.resolve(value),
+    (value) => `${value}`
+);
+
+myComponent.props = {
+    check: { type: TypeLoad },
+};
+
+const MyComponent = c(myComponent);
+
+<MyComponent check={10}>...</MyComponent>;


### PR DESCRIPTION
# 1.73.0
1. Add support for custom types.
2. Introduce the use of the 'new' operator to create an instance of an uncovered attribute.
3. Prevent the loss of options by avoiding module references and using a global based on symbols.
4. Remove the module at the atomico/core level for types.
5. Add support for AbortController to the useAsync, useSuspense, and usePromise hooks.