### PR TITLE
Next 2.0.0 element internals

### DIFF
--- a/developer experience/context/package.json
+++ b/developer experience/context/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@atomico/dx-context",
+    "name": "-context",
     "version": "1.0.0",
     "private": true,
     "type": "module",

--- a/developer experience/hooks/index.html
+++ b/developer experience/hooks/index.html
@@ -11,6 +11,10 @@
         </style>
     </head>
     <body>
+        <form>
+            <eg-use-internals></eg-use-internals>
+        </form>
+        <hr />
         <eg-use-effect></eg-use-effect>
         <eg-use-slot>
             <h1>welcome</h1>

--- a/developer experience/hooks/index.html
+++ b/developer experience/hooks/index.html
@@ -11,11 +11,19 @@
         </style>
     </head>
     <body>
-        <form>
+        <form
+            id="ff"
+            onsubmit="event.preventDefault()
+        
+            console.log(Object.fromEntries(new FormData(ff)))
+        "
+        >
             <eg-use-internals></eg-use-internals>
+            <input type="text" required name="email" />
+            <button>Submit</button>
         </form>
         <hr />
-        <eg-use-effect></eg-use-effect>
+        <!-- <eg-use-effect></eg-use-effect>
         <eg-use-slot>
             <h1>welcome</h1>
         </eg-use-slot>
@@ -33,7 +41,7 @@
             </button>
         </eg-use-nodes>
         <hr />
-        <eg-use-render>...</eg-use-render>
+        <eg-use-render>...</eg-use-render> -->
         <script type="module" src="./src/index.tsx"></script>
     </body>
 </html>

--- a/developer experience/hooks/package.json
+++ b/developer experience/hooks/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@atomico/dx-hooks",
+    "name": "-hooks",
     "version": "1.0.0",
     "private": true,
     "type": "module",

--- a/developer experience/hooks/src/index.tsx
+++ b/developer experience/hooks/src/index.tsx
@@ -1,4 +1,5 @@
-import "./use-slot";
-import "./use-nodes";
-import "./use-render";
-import "./use-effect";
+import "./use-slot.js";
+import "./use-nodes.js";
+import "./use-render.js";
+import "./use-effect.js";
+import "./use-internals.js";

--- a/developer experience/hooks/src/use-internals.tsx
+++ b/developer experience/hooks/src/use-internals.tsx
@@ -1,0 +1,12 @@
+import { c, useEffect, useState, useUpdate } from "atomico";
+
+export const EgUseEffect = c(
+    () => {
+        return <host shadowDom>Form!</host>;
+    },
+    {
+        form: true
+    }
+);
+
+customElements.define("eg-use-internals", EgUseEffect);

--- a/developer experience/hooks/src/use-internals.tsx
+++ b/developer experience/hooks/src/use-internals.tsx
@@ -1,8 +1,40 @@
-import { c, useEffect, useState, useUpdate } from "atomico";
+import { c, useEffect, useHost, useState, useUpdate } from "atomico";
 
 export const EgUseEffect = c(
     () => {
-        return <host shadowDom>Form!</host>;
+        const { current } = useHost();
+        const [internal] = useState(() => current.attachInternals());
+        return (
+            <host shadowDom>
+                Form!
+                <input
+                    type="text"
+                    oninput={({ currentTarget }) => {
+                        const form = new FormData();
+                        form.append("mi-text", `${currentTarget.value}`);
+                        internal.setFormValue(form);
+                    }}
+                />
+                <button
+                    onclick={() => {
+                        internal.setValidity(
+                            { valueMissing: true },
+                            "my message"
+                        );
+                        internal.reportValidity();
+                    }}
+                >
+                    message
+                </button>
+                <button
+                    onclick={() => {
+                        console.log(internal.checkValidity());
+                    }}
+                >
+                    check
+                </button>
+            </host>
+        );
     },
     {
         form: true

--- a/developer experience/todo/package.json
+++ b/developer experience/todo/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@atomico/dx-todo",
+    "name": "-todo",
     "version": "1.0.0",
     "private": true,
     "type": "module",

--- a/developer experience/types/package.json
+++ b/developer experience/types/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@atomico/dx-types",
+    "name": "-types",
     "type": "module",
     "private": true,
     "scripts": {

--- a/src/element/custom-element.js
+++ b/src/element/custom-element.js
@@ -7,6 +7,12 @@ import { createHooks, UNMOUNT } from "../hooks/create-hooks.js";
 import { flat } from "../utils.js";
 import { ParseError } from "./errors.js";
 import { setPrototype, transformValue } from "./set-prototype.js";
+import {
+    FORM_ASSOCIATED,
+    FORM_DISABLED,
+    FORM_RESET,
+    FORM_RESTORE
+} from "../hooks/custom-hooks/use-internals.js";
 export { Any, event } from "./set-prototype.js";
 
 let ID = 0;
@@ -32,10 +38,12 @@ export const c = (component, options) => {
     const {
         props,
         styles,
+        form,
         base = HTMLElement
     } = { props: {}, base: HTMLElement, ...options };
 
     class AtomicoElement extends base {
+        static formAssociated = form;
         constructor() {
             super();
             this._setup();
@@ -166,6 +174,24 @@ export const c = (component, options) => {
         static get props() {
             return props;
         }
+    }
+
+    if (form) {
+        [FORM_ASSOCIATED, FORM_DISABLED, FORM_RESET, FORM_RESTORE].forEach(
+            (method) => {
+                /**
+                 * @this {import("dom").AtomicoThisInternal}
+                 * @param {...any} args
+                 */
+                AtomicoElement.prototype[`${method}Callback`] = async function (
+                    ...args
+                ) {
+                    await this.updated;
+
+                    this._hooks.dispatch(`${method}`, args);
+                };
+            }
+        );
     }
     // @ts-ignore
     return AtomicoElement;

--- a/src/hooks/create-hooks.js
+++ b/src/hooks/create-hooks.js
@@ -13,7 +13,7 @@ let SCOPE = globalThis[ID];
 /**
  * Error id to escape execution of hooks.render
  */
-export const UNMOUNT = SymbolFor("hook/unmount");
+export const UNMOUNT = "unmount";
 /**
  * Error id to escape execution of hooks.render
  */

--- a/src/hooks/custom-hooks/use-internals.js
+++ b/src/hooks/custom-hooks/use-internals.js
@@ -1,0 +1,32 @@
+import { SymbolFor } from "../../utils.js";
+import { useWhen, useHost } from "../create-hooks.js";
+
+export const FORM_ASSOCIATED = "formAssociated";
+export const FORM_DISABLED = "formDisabled";
+export const FORM_RESET = "formReset";
+export const FORM_RESTORE = "formStateRestore";
+
+const ID = SymbolFor("hook/internals");
+
+export const useInternals = () => {
+    const { current } = useHost();
+
+    current[ID] = current[ID] || current.attachInternals();
+
+    return current[ID];
+};
+
+export const useFormValue = () => {};
+
+/**
+ *
+ * @param {string} method
+ * @returns {(callback:(...any:any[])=>any)=>void}
+ */
+const createFormMethod = (method) => (callback) =>
+    useWhen(method, (args) => callback(...args));
+
+export const useFormAssociated = createFormMethod(FORM_ASSOCIATED);
+export const useFormDisabled = createFormMethod(FORM_DISABLED);
+export const useFormReset = createFormMethod(FORM_RESET);
+export const useformStateRestore = createFormMethod(FORM_RESTORE);

--- a/src/hooks/test-hooks.js
+++ b/src/hooks/test-hooks.js
@@ -1,2 +1,10 @@
 export { EFFECT, LAYOUT_EFFECT, INSERTION_EFFECT } from "./use-effect.js";
+
+export {
+    FORM_ASSOCIATED,
+    FORM_DISABLED,
+    FORM_RESET,
+    FORM_RESTORE
+} from "./custom-hooks/use-internals.js";
+
 export { UNMOUNT, createHooks } from "./create-hooks.js";

--- a/src/hooks/use-effect.js
+++ b/src/hooks/use-effect.js
@@ -1,25 +1,25 @@
-import { isEqualArray, SymbolFor } from "../utils.js";
+import { isEqualArray } from "../utils.js";
 import { UNMOUNT, useRef, useWhen } from "./create-hooks.js";
 
 /**
  * tag to identify the useEffect
  */
-export const EFFECT = SymbolFor("hook/effect");
+export const EFFECT = "effect";
 
 /**
  * tag to identify the useLayoutEffect
  */
-export const LAYOUT_EFFECT = SymbolFor("hook/layoutEffect");
+export const LAYOUT_EFFECT = "layoutEffect";
 
 /**
  * tag to identify the useInsertionEffect
  */
-export const INSERTION_EFFECT = SymbolFor("hook/insertionEffect");
+export const INSERTION_EFFECT = "insertionEffect";
 
 /**
  * useLayoutEffect and useEffect have a similar algorithm
  * in that the position of the callback varies.
- * @param { LAYOUT_EFFECT | EFFECT | INSERTION_EFFECT } type
+ * @param { string | symbol } type
  * @return {import("internal/hooks.js").UseAnyEffect}
  */
 const createEffect = (type) => (effect, currentArgs) => {

--- a/types/component.d.ts
+++ b/types/component.d.ts
@@ -2,8 +2,8 @@ import { Atomico } from "./dom.js";
 import {
     EventFunction,
     InferProps,
-    SchemaComponentStylesConfig,
     SchemaComponentConfig,
+    SchemaComponentGenericConfig,
     ShemaConfigEvent
 } from "./schema.js";
 
@@ -21,12 +21,12 @@ export interface View<Config extends SchemaComponentConfig> {
 
 export type DefineConfig<Config> = Config extends SchemaComponentConfig
     ? Config
-    : Config extends SchemaComponentStylesConfig
+    : Config extends SchemaComponentGenericConfig
     ? Config & EmptyProps
     : EmptyProps;
 
 export type C = <
-    Config extends SchemaComponentConfig | SchemaComponentStylesConfig
+    Config extends SchemaComponentConfig | SchemaComponentGenericConfig
 >(
     view: View<DefineConfig<Config>>,
     config?: Config

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -1,14 +1,15 @@
+import { CreateHooks } from "internal/hooks.js";
 import { Sheet } from "./css.js";
 import { DOMFormElement, DOMFormElements } from "./dom-html.js";
 import { SVGProperties } from "./dom-svg.js";
-import { SchemaRecord } from "./schema.js";
-import { VNodeKeyTypes } from "./vnode.js";
 import {
-    SchemaComponentConfig,
-    InferPropsWithEvents,
     InferAttrsFromProps,
-    InferProps
+    InferProps,
+    InferPropsWithEvents,
+    SchemaComponentConfig,
+    SchemaRecord
 } from "./schema.js";
+import { VNodeKeyTypes } from "./vnode.js";
 
 export type Nullable<T> = NonNullable<T> | undefined | null;
 
@@ -272,14 +273,15 @@ export type DOMProps<props> = Partial<Omit<props, DOMEventHandlerKeys<props>>>;
 
 export type AtomicoThisInternal = AtomicoThis & {
     _props: { [prop: string]: any };
+    _hooks: ReturnType<CreateHooks>;
     _ignoreAttr?: string | null;
-    mount?: () => void;
-    umount?: () => void;
+    _umount?: () => void;
     shadowRoot?: {
         adoptedStyleSheets: CSSStyleSheet[];
     };
     constructor: {
         styles: Sheet[];
+        form: boolean;
     };
 };
 

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -105,7 +105,10 @@ export type UseHook = <Render extends (arg?: any) => any>(
 /**
  * UseWhen
  */
-export type UseWhen = (id: symbol, callback: (param?: any) => any) => void;
+export type UseWhen = (
+    id: symbol | string,
+    callback: (param?: any) => any
+) => void;
 
 /**
  * UseRef

--- a/types/internal/hooks.d.ts
+++ b/types/internal/hooks.d.ts
@@ -4,8 +4,6 @@ export type Effect = (state: any, unmounted?: boolean) => any;
 
 export type Hook = {
     value?: any;
-    effect?: Effect;
-    tag?: symbol | string | number;
 };
 
 /**

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -61,10 +61,21 @@ export interface PropTypes {
 export interface SchemaComponentStylesConfig {
     styles?: Sheets;
 }
+export interface SchemaComponentFormConfig {
+    config?: boolean;
+}
 
-export interface SchemaComponentConfig extends SchemaComponentStylesConfig {
+export interface SchemaComponentBaseConfig {
+    base?: typeof HTMLElement;
+}
+
+export interface SchemaComponentGenericConfig
+    extends SchemaComponentStylesConfig,
+        SchemaComponentFormConfig,
+        SchemaComponentBaseConfig {}
+
+export interface SchemaComponentConfig extends SchemaComponentGenericConfig {
     props: PropTypes;
-    styles?: Sheets;
 }
 
 export interface ShemaConfigEvent<Detail> extends EventInit {

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -62,7 +62,7 @@ export interface SchemaComponentStylesConfig {
     styles?: Sheets;
 }
 export interface SchemaComponentFormConfig {
-    config?: boolean;
+    form?: boolean;
 }
 
 export interface SchemaComponentBaseConfig {


### PR DESCRIPTION
At the core level, the way a hook's lifecycle is communicated is modified to reflect new lifecycle events without needing to create an effect at the core level.  

This is achieved through a subscriber model with the new internal hook `useWhen`, which allows observing an event at the symbol or string level.  

You can see this implementation in `use-effect` and `use-internals`.  

The lifecycle IDs for subscribers are exposed at `atomico/test-hooks`.