### PR TITLE
Feat/use object state

### DIFF
--- a/developer-experience/hooks/example-use-object-state.html
+++ b/developer-experience/hooks/example-use-object-state.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Atomico: useObjectState Example</title>
+        <script type="module" src="./src/example-use-object-state.tsx"></script>
+    </head>
+    <body>
+        <example-use-object-state></example-use-object-state>
+    </body>
+</html>

--- a/developer-experience/hooks/index.html
+++ b/developer-experience/hooks/index.html
@@ -40,6 +40,9 @@
             <li>
                 <a href="./example-use-parent.html">example-parent</a>
             </li>
+            <li>
+                <a href="./example-use-object-state.html">example-use-object-state</a>
+            </li>
         </ul>
     </body>
 </html>

--- a/developer-experience/hooks/src/example-use-object-state.tsx
+++ b/developer-experience/hooks/src/example-use-object-state.tsx
@@ -1,0 +1,81 @@
+/**
+ * The next example demonstrates the useObjectState hook in Atomico.
+ * useObjectState provides a simple way to manage object state with
+ * automatic shallow merging and render prevention when values are identical.
+ */
+import { c, useObjectState, useRef, useEffect } from "atomico";
+
+export const EgUseObjectState = c(() => {
+    // 1. Declare state as a typed object
+    const [state, setState] = useObjectState({
+        name: "Antigravity",
+        role: "AI Agent",
+        clicks: 0
+    });
+
+    // Keep track of renders to visually demonstrate the rendering optimization!
+    const renderCountRef = useRef(0);
+    renderCountRef.current++;
+
+
+    // Effect to demonstrate when state actually changes
+    useEffect(() => {
+        console.log("State updated in component:", state);
+    }, [state]);
+
+    return (
+        <host style="display: block; font-family: sans-serif; max-width: 400px; padding: 20px; border: 1px solid #ccc; border-radius: 8px; margin: 20px;">
+            <h3>Atomico: <code>useObjectState</code> Example</h3>
+            
+            <div style="background: #f4f4f4; padding: 10px; border-radius: 4px; margin-bottom: 15px;">
+                <strong>Current State:</strong>
+                <pre style="margin: 5px 0 0 0; font-size: 13px;">
+                    {JSON.stringify(state, null, 2)}
+                </pre>
+            </div>
+
+            <div style="margin-bottom: 15px; color: #666; font-size: 14px;">
+                🔄 <strong>Render Count:</strong> {renderCountRef.current}
+            </div>
+
+            <div style="display: flex; flex-direction: column; gap: 8px;">
+                {/* 1. Partial Update changing a value */}
+                <button
+                    style="padding: 8px; cursor: pointer; background: #0070f3; color: white; border: none; border-radius: 4px;"
+                    onclick={() => {
+                        setState((prev) => ({ clicks: prev.clicks + 1 }));
+                    }}
+                >
+                    Increment clicks (Changes state)
+                </button>
+
+                {/* 2. Partial Update with IDENTICAL value (Demonstrates Render Prevention) */}
+                <button
+                    style="padding: 8px; cursor: pointer; background: #ea4335; color: white; border: none; border-radius: 4px;"
+                    onclick={() => {
+                        console.log("Despachando { name: 'Antigravity' } (No cambia valor)");
+                        setState({ name: "Antigravity" });
+                    }}
+                >
+                    Set name to 'Antigravity' (No change, no render!)
+                </button>
+
+                {/* 3. Partial Update changing name */}
+                <button
+                    style="padding: 8px; cursor: pointer; background: #34a853; color: white; border: none; border-radius: 4px;"
+                    onclick={() => {
+                        setState({ name: "Atomico" });
+                    }}
+                >
+                    Change name to 'Atomico' (Changes value)
+                </button>
+            </div>
+            
+            <p style="font-size: 12px; color: #888; margin-top: 15px; text-align: center;">
+                Check the console to observe rendering logs.
+            </p>
+        </host>
+    );
+});
+
+customElements.define("example-use-object-state", EgUseObjectState);

--- a/src/hooks/custom-hooks.js
+++ b/src/hooks/custom-hooks.js
@@ -19,3 +19,5 @@ export {
     useInternals
 } from "./custom-hooks/use-internals.js";
 export { useSuspense } from "./custom-hooks/use-suspense.js";
+export * from "./custom-hooks/use-object-state.js";
+

--- a/src/hooks/custom-hooks/use-object-state.js
+++ b/src/hooks/custom-hooks/use-object-state.js
@@ -2,7 +2,7 @@ import { useHook, useUpdate } from "../create-hooks.js";
 import { createState } from "../state.js";
 /**
  * Create a persistent local state
- * @type {import("core").UseState}
+ * @type {import("core").UseObjectState}
  */
 export const useObjectState = (initialState) => {
     // retrieve the render to request an update

--- a/src/hooks/custom-hooks/use-object-state.js
+++ b/src/hooks/custom-hooks/use-object-state.js
@@ -1,0 +1,24 @@
+import { useHook, useUpdate } from "../create-hooks.js";
+import { createState } from "../state.js";
+/**
+ * Create a persistent local state
+ * @type {import("core").UseState}
+ */
+export const useObjectState = (initialState) => {
+    // retrieve the render to request an update
+    const update = useUpdate();
+    return useHook(
+        (
+            state = createState(initialState, update, (state, newState) => {
+                let changed = false;
+                for (const key in newState) {
+                    if (state[key] !== newState[key]) {
+                        changed = true;
+                        break;
+                    }
+                }
+                return changed ? { ...state, ...newState } : state;
+            })
+        ) => state
+    );
+};

--- a/src/hooks/state.js
+++ b/src/hooks/state.js
@@ -3,8 +3,9 @@ import { isFunction } from "../utils.js";
  *
  * @param {any} initialState
  * @param {(state: any)=>any} update
+ * @param {(state: any, nextState: any)=>any} [map]
  */
-export function createState(initialState, update) {
+export function createState(initialState, update, map) {
     /**  @type {[any, (state:any)=>any]} */
     const state = [
         isFunction(initialState) ? initialState() : initialState,
@@ -13,7 +14,9 @@ export function createState(initialState, update) {
                 ? nextState(state[0])
                 : nextState;
 
-            value !== state[0] && update((state[0] = value));
+            const nextValue = map ? map(state[0], value) : value;
+
+            nextValue !== state[0] && update((state[0] = nextValue));
         }
     ];
     return state;

--- a/src/hooks/tests/use-object-state.test.ts
+++ b/src/hooks/tests/use-object-state.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { createHooks } from "../create-hooks.js";
+import { useObjectState } from "../custom-hooks/use-object-state.js";
+
+describe("src/hooks/use-object-state", () => {
+    it("initialization and basic object state rendering", () => {
+        let renderCount = 0;
+        let render = () => {
+            renderCount++;
+        };
+        let hooks = createHooks(render);
+
+        let load = () => {
+            let [state] = useObjectState({ name: "Atomico", version: 1 });
+            expect(state).to.deep.equal({ name: "Atomico", version: 1 });
+        };
+
+        hooks.render(load);
+        expect(renderCount).to.equal(0); // Synchronous initial render does not trigger update callbacks
+    });
+
+    it("partial state updates via object merge", () => {
+        let step = 0;
+        let render = () => {
+            hooks.render(load);
+        };
+
+        let hooks = createHooks(render);
+
+        let load = () => {
+            let [state, setState] = useObjectState({ name: "Atomico", version: 1 });
+            
+            if (step === 0) {
+                expect(state).to.deep.equal({ name: "Atomico", version: 1 });
+                step = 1;
+                setState({ version: 2 });
+            } else if (step === 1) {
+                expect(state).to.deep.equal({ name: "Atomico", version: 2 });
+                step = 2;
+                setState({ name: "Super Atomico" });
+            } else if (step === 2) {
+                expect(state).to.deep.equal({ name: "Super Atomico", version: 2 });
+            }
+        };
+
+        render();
+        expect(step).to.equal(2);
+    });
+
+    it("updates state using functional callbacks", () => {
+        let step = 0;
+        let render = () => {
+            hooks.render(load);
+        };
+
+        let hooks = createHooks(render);
+
+        let load = () => {
+            let [state, setState] = useObjectState({ clicks: 0 });
+
+            if (step === 0) {
+                expect(state).to.deep.equal({ clicks: 0 });
+                step = 1;
+                setState((prev) => ({ clicks: prev.clicks + 1 }));
+            } else if (step === 1) {
+                expect(state).to.deep.equal({ clicks: 1 });
+            }
+        };
+
+        render();
+        expect(step).to.equal(1);
+    });
+
+    it("prevents re-renders when incoming partial values are identical", () => {
+        let renderCount = 0;
+        let render = () => {
+            renderCount++;
+            hooks.render(load);
+        };
+
+        let hooks = createHooks(render);
+
+        let load = () => {
+            let [, setState] = useObjectState({ name: "Antigravity", count: 10 });
+
+            if (renderCount === 1) {
+                // Dispatching identical property should not enqueue a second render
+                setState({ name: "Antigravity" });
+            }
+        };
+
+        render();
+        expect(renderCount).to.equal(1); // Rendered exactly once
+    });
+});

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -102,6 +102,18 @@ export const useProp: Hooks.UseProp;
 export const useState: Hooks.UseState;
 
 /**
+ * create a private object state in the customElement that merges updates automatically
+ * ```js
+ * function component(){
+ *     const [ state, setState ] = useObjectState({ count: 0, title: "" });
+ *     return <host>{ state.count }</host>;
+ * }
+ * ```
+ */
+export const useObjectState: Hooks.UseObjectState;
+
+
+/**
  * Create or recover a persistent reference between renders.
  * ```js
  * const ref = useRef();

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -117,7 +117,10 @@ export type UseWhen = (
 /**
  * UseRef
  */
-export type UseRef = <Target = any>(current?: Target) => Ref<Target>;
+export type UseRef = {
+    <Target = any>(): Ref<Target>;
+    <Target = any>(current: Target): Required<Ref<Target>>;
+};
 
 export type UseHost = <Target = AtomicoThis>() => Required<Ref<Target>>;
 
@@ -308,3 +311,14 @@ export type UseParent = <Element extends string | typeof HTMLElement>(
     element: Element,
     composed?: boolean
 ) => Ref<Element extends HTMLElement ? Element : HTMLElement>;
+
+export type SetObjectState<State> = (
+    state: Partial<State> | ((reduce: State) => Partial<State>)
+) => void;
+
+export type ReturnUseObjectState<Value> = State<Value, SetObjectState<Value>>;
+
+export type UseObjectState = <OptionalInitialState extends object = any>(
+    initialState?: OptionalInitialState | (() => OptionalInitialState)
+) => ReturnUseObjectState<GetInitialState<OptionalInitialState>>;
+


### PR DESCRIPTION
# CHANGELOG
## 🚀 Added
* **`useObjectState` Hook**: Manages complex object states with automatic shallow merging.
* **Render-Prevention**: Automatically aborts re-renders if partial updates contain identical values (improving CPU/GC efficiency).
* **`createState` Extensibility**: Modified the core to support custom state mergers/reducers.
## 🐛 Fixed
* **`useRef` Typings**: Fixed a bug where `current` was marked as optional even when an initial value was provided. Added overloads to return `Required<Ref<Target>>`.
---
## 💡 Code Simplification Example
### Before (Multiple States)
```tsx
const [title, setTitle] = useState("");
const [category, setCategory] = useState("Personal");
const [clicks, setClicks] = useState(0);
// Updates required multiple calls:
setTitle("");
setCategory("Personal");
```

## After (Single useObjectState)

```tsx
const [state, setState] = useObjectState({
    title: "",
    category: "Personal",
    clicks: 0
});
// Single partial update (prevents redundant renders if values are identical):
setState({ title: "", category: "Personal" });

// OR (Partial)
setState({ title: "Atomico"});
```