### PR TITLE
Fix event propagation crash in `useEvent`

### DIFF
--- a/src/element/set-prototype.js
+++ b/src/element/set-prototype.js
@@ -1,5 +1,7 @@
-import { isObject } from "../utils.js";
+import { isObject, SymbolFor } from "../utils.js";
 import { PropError } from "./errors.js";
+
+export const SYMBOL_EVENT = SymbolFor("event");
 
 /**
  * The Any type avoids the validation of prop types
@@ -187,12 +189,14 @@ export const filterValue = (type, value) =>
 export const event = (config) => ({
     type: Function,
     value() {
-        return (detail) =>
+        const dispatch = (detail) =>
             dispatchEvent(this.self, {
                 ...config,
                 type: this.prop,
                 detail: detail || config?.detail
             });
+        dispatch[SYMBOL_EVENT] = true;
+        return dispatch;
     }
 });
 

--- a/src/hooks/custom-hooks/use-event.js
+++ b/src/hooks/custom-hooks/use-event.js
@@ -10,7 +10,7 @@ export const useEvent = (type, eventInit = {}) => {
     if (!ref[type]) {
         ref[type] = (detail = eventInit.detail) => {
             const target = ref.current[type];
-            if (isFunction(target) && (target[SYMBOL_EVENT] || type === "click")) {
+            if (isFunction(target) && target[SYMBOL_EVENT]) {
                 target(detail);
             } else {
                 dispatchEvent(ref.current, {

--- a/src/hooks/custom-hooks/use-event.js
+++ b/src/hooks/custom-hooks/use-event.js
@@ -1,5 +1,6 @@
 import { useHost } from "../create-hooks.js";
-import { dispatchEvent } from "../../element/set-prototype.js";
+import { dispatchEvent, SYMBOL_EVENT } from "../../element/set-prototype.js";
+import { isFunction } from "../../utils.js";
 
 /**
  * @type {import("core").UseEvent}
@@ -8,8 +9,9 @@ export const useEvent = (type, eventInit = {}) => {
     const ref = useHost();
     if (!ref[type]) {
         ref[type] = (detail = eventInit.detail) => {
-            if (type in ref.current) {
-                ref.current[type](detail);
+            const target = ref.current[type];
+            if (isFunction(target) && (target[SYMBOL_EVENT] || type === "click")) {
+                target(detail);
             } else {
                 dispatchEvent(ref.current, {
                     type,

--- a/src/hooks/tests/use-event.test.ts
+++ b/src/hooks/tests/use-event.test.ts
@@ -125,4 +125,30 @@ describe("src/hooks/custom-hooks/use-event", () => {
 
         expect(done).toBeCalledTimes(1);
     });
+
+    it("falls back to dispatchEvent when property is not a function or lacks the event symbol", () => {
+        let el = document.createElement("div");
+        // Create a non-function property that is present on the element
+        // @ts-ignore
+        el.myPrimitiveProp = "hello";
+
+        let hooks = createHooks(null, el);
+        let typeEvent = "myPrimitiveProp";
+        const done = vi.fn();
+
+        el.addEventListener(typeEvent, () => {
+            done();
+        });
+
+        let load = () => {
+            let dispatchEvent = useEvent(typeEvent);
+            // This should not throw TypeError: el.myPrimitiveProp is not a function.
+            // It should fall back to dispatchEvent.
+            dispatchEvent();
+        };
+
+        hooks.render(load);
+
+        expect(done).toBeCalledTimes(1);
+    });
 });


### PR DESCRIPTION

## 🐛 Bug Fixes & Core Improvements
### Event propagation crash resolved in `useEvent`
* **Tagged Event Callbacks:** Introduced a internal symbol `SYMBOL_EVENT` (`Symbol.for("atomico/event")`) to tag custom event dispatchers created via the `event()` prop creator inside `src/element/set-prototype.js`.
* **Strict Event Callback Invocation:** Refactored the `useEvent` hook in `src/hooks/custom-hooks/use-event.js` to use the `isFunction` helper. It now strictly invokes the target property on the element **only if** it is a function and possesses the `SYMBOL_EVENT` marker.
* **Safe Fallback to `dispatchEvent`:** If the element defines a non-function property (such as `.value` or `.title`) or a native DOM method (such as `.click()`) that shares a name with the event type, the hook safely falls back to standard DOM `dispatchEvent` instead of throwing a `TypeError` or triggering native DOM actions.
* **Regression Testing:** Added a new test suite inside `src/hooks/tests/use-event.test.ts` to ensure that triggering events on elements with non-function properties does not crash the element.
---
## 📝 Code Changes
### `src/element/set-prototype.js`
* Added `SYMBOL_EVENT` definition.
* Tagged functions returned by the `event` descriptor with `dispatch[SYMBOL_EVENT] = true`.
### `src/hooks/custom-hooks/use-event.js`
* Replaced the loose `in` check with a strict check using `isFunction` and the `SYMBOL_EVENT` marker.
### `src/hooks/tests/use-event.test.ts`
* Added the test: `"falls back to dispatchEvent when property is not a function or lacks the event symbol"`.